### PR TITLE
[Fix #214] Fix a false positive for `Performance/RedundantEqualityComparisonBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#207](https://github.com/rubocop/rubocop-performance/issues/207): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using multiple block arguments. ([@koic][])
+
 ## 1.10.0 (2021-03-01)
 
 ### New features

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -34,7 +34,7 @@ module RuboCop
         COMPARISON_METHODS = %i[== === is_a? kind_of?].freeze
 
         def on_block(node)
-          return unless TARGET_METHODS.include?(node.method_name)
+          return unless TARGET_METHODS.include?(node.method_name) && node.arguments.one?
 
           block_argument = node.arguments.first
           block_body = node.body

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       RUBY
     end
 
+    it 'does not register and corrects an offense when using multiple block arguments' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |key, _value| key == other }
+      RUBY
+    end
+
     it 'does not register and corrects an offense when using block argument is not used as it is' do
       expect_no_offenses(<<~RUBY)
         items.all? { |item| item.do_something == other }


### PR DESCRIPTION
Fixes #214.

This PR fixes a false positive for `Performance/RedundantEqualityComparisonBlock` when using multiple block arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
