### PR TITLE
[Fix #217] Fix a false positive for `Performance/RedundantEqualityComparisonBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#214](https://github.com/rubocop/rubocop-performance/issues/214): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using multiple block arguments. ([@koic][])
 * [#216](https://github.com/rubocop/rubocop-performance/issues/216): Fix a false positive for `Performance/RedundantSplitRegexpArgument` when using split method with ignore case regexp option. ([@koic][])
+* [#217](https://github.com/rubocop/rubocop-performance/issues/217): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using block argument is used for an argument of `is_a`. ([@koic][])
 
 ## 1.10.0 (2021-03-01)
 

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -32,6 +32,7 @@ module RuboCop
 
         TARGET_METHODS = %i[all? any? one? none?].freeze
         COMPARISON_METHODS = %i[== === is_a? kind_of?].freeze
+        IS_A_METHODS = %i[is_a? kind_of?].freeze
 
         def on_block(node)
           return unless TARGET_METHODS.include?(node.method_name) && node.arguments.one?
@@ -39,6 +40,7 @@ module RuboCop
           block_argument = node.arguments.first
           block_body = node.body
           return unless use_equality_comparison_block?(block_body)
+          return if same_block_argument_and_is_a_argument?(block_body, block_argument)
           return unless (new_argument = new_argument(block_argument, block_body))
 
           range = offense_range(node)
@@ -53,6 +55,12 @@ module RuboCop
 
         def use_equality_comparison_block?(block_body)
           block_body.send_type? && COMPARISON_METHODS.include?(block_body.method_name)
+        end
+
+        def same_block_argument_and_is_a_argument?(block_body, block_argument)
+          return false unless IS_A_METHODS.include?(block_body.method_name)
+
+          block_argument.source == block_body.first_argument.source
         end
 
         def new_argument(block_argument, block_body)

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       RUBY
     end
 
+    it 'does not register an offense when using block argument is used for an argument of `is_a`' do
+      expect_no_offenses(<<~RUBY)
+        klasses.all? { |klass| item.is_a?(klass) }
+      RUBY
+    end
+
+    it 'does not register an offense when using block argument is used for an argument of `kind_of?`' do
+      expect_no_offenses(<<~RUBY)
+        klasses.all? { |klass| item.kind_of?(klass) }
+      RUBY
+    end
+
     it 'does not register and corrects an offense when using block argument is not used as it is' do
       expect_no_offenses(<<~RUBY)
         items.all? { |item| item.do_something == other }


### PR DESCRIPTION
Fixes #217.

This PR fixes a false positive for `Performance/RedundantEqualityComparisonBlock` when using block argument is used for an argument of `is_a`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
