### PR TITLE
[Fix #216] Fix a false positive for `Performance/RedundantSplitRegexpArgument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#214](https://github.com/rubocop/rubocop-performance/issues/214): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using multiple block arguments. ([@koic][])
+* [#216](https://github.com/rubocop/rubocop-performance/issues/216): Fix a false positive for `Performance/RedundantSplitRegexpArgument` when using split method with ignore case regexp option. ([@koic][])
 
 ## 1.10.0 (2021-03-01)
 

--- a/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe RuboCop::Cop::Performance::RedundantSplitRegexpArgument, :config 
     expect_no_offenses("'a,b,c'.split(/,+/)")
   end
 
+  it 'accepts when using split method with ignorecase regexp option' do
+    expect_no_offenses("'fooSplitbar'.split(/split/i)")
+  end
+
   it 'registers an offense when the method is split and correctly removes escaping characters' do
     expect_offense(<<~RUBY)
       'a,b,c'.split(/\\./)


### PR DESCRIPTION
Fixes #216.

This PR fixes a false positive for `Performance/RedundantSplitRegexpArgument` when using split method with ignore case regexp option.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
