### PR TITLE
[Fix #162] Fix a false positive for `Performance/RedundantBlockCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#162](https://github.com/rubocop/rubocop-performance/issues/162): Fix a false positive for `Performance/RedundantBlockCall` when an optional block that is overridden by block variable. ([@koic][])
+
 ## 1.10.1 (2021-03-02)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -78,13 +78,19 @@ module RuboCop
         end
 
         def calls_to_report(argname, body)
-          return [] if blockarg_assigned?(body, argname)
+          return [] if blockarg_assigned?(body, argname) || shadowed_block_argument?(body, argname)
 
           blockarg_calls(body, argname).map do |call|
             return [] if args_include_block_pass?(call)
 
             call
           end
+        end
+
+        def shadowed_block_argument?(body, block_argument_of_method_signature)
+          return false unless body.block_type?
+
+          body.arguments.map(&:source).include?(block_argument_of_method_signature.to_s)
         end
 
         def args_include_block_pass?(blockcall)


### PR DESCRIPTION
Fixes #162.

This PR fixes a false positive for `Performance/RedundantBlockCall` when an optional block that is overridden by block variable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
