### PR TITLE
[Fix #36] Fix a false positive for `Performance/ReverseEach`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#162](https://github.com/rubocop/rubocop-performance/issues/162): Fix a false positive for `Performance/RedundantBlockCall` when an optional block that is overridden by block variable. ([@koic][])
+* [#36](https://github.com/rubocop/rubocop-performance/issues/36): Fix a false positive for `Performance/ReverseEach` when `each` is called on `reverse` and using the result value. ([@koic][])
 
 ## 1.10.1 (2021-03-02)
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1530,15 +1530,23 @@ end
 This cop is used to identify usages of `reverse.each` and
 change them to use `reverse_each` instead.
 
+If the return value is used, it will not be detected because the result will be different.
+
+[source,ruby]
+----
+[1, 2, 3].reverse.each {} #=> [3, 2, 1]
+[1, 2, 3].reverse_each {} #=> [1, 2, 3]
+----
+
 === Examples
 
 [source,ruby]
 ----
 # bad
-[].reverse.each
+items.reverse.each
 
 # good
-[].reverse_each
+items.reverse_each
 ----
 
 === References

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -129,4 +129,46 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach, :config do
       RUBY
     end
   end
+
+  it 'does not register an offense when each is called on reverse and assign the result to lvar' do
+    expect_no_offenses(<<~RUBY)
+      ret = [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and assign the result to ivar' do
+    expect_no_offenses(<<~RUBY)
+      @ret = [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and assign the result to cvar' do
+    expect_no_offenses(<<~RUBY)
+      @@ret = [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and assign the result to gvar' do
+    expect_no_offenses(<<~RUBY)
+      $ret = [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and assign the result to constant' do
+    expect_no_offenses(<<~RUBY)
+      RET = [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and using the result to method chain' do
+    expect_no_offenses(<<~RUBY)
+      [1, 2, 3].reverse.each { |e| puts e }.last
+    RUBY
+  end
+
+  it 'does not register an offense when each is called on reverse and returning the result' do
+    expect_no_offenses(<<~RUBY)
+      return [1, 2, 3].reverse.each { |e| puts e }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #36.

This PR fixes a false positive for `Performance/ReverseEach` when `each` is called on `reverse` and using the result value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
