### PR TITLE
[Fix #222] Fix a false positive for `Performance/RedundantSplitRegexpArgument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#36](https://github.com/rubocop/rubocop-performance/issues/36): Fix a false positive for `Performance/ReverseEach` when `each` is called on `reverse` and using the result value. ([@koic][])
 * [#224](https://github.com/rubocop/rubocop-performance/pull/224): Fix a false positive for `Style/RedundantEqualityComparisonBlock` when using one argument with comma separator in block argument. ([@koic][])
 * [#225](https://github.com/rubocop/rubocop-performance/issues/225): Fix a false positive for `Style/RedundantEqualityComparisonBlock` when using `any?` with `===` comparison block and block argument is not used as a receiver for `===`. ([@koic][])
+* [#222](https://github.com/rubocop/rubocop-performance/issues/222): Fix a false positive for `Performance/RedundantSplitRegexpArgument` when `split` method argument is exactly one spece regexp `/ /`. ([@koic][])
 
 ## 1.10.1 (2021-03-02)
 

--- a/lib/rubocop/cop/performance/redundant_split_regexp_argument.rb
+++ b/lib/rubocop/cop/performance/redundant_split_regexp_argument.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def on_send(node)
           return unless (regexp_node = split_call_with_regexp?(node))
-          return if regexp_node.ignore_case?
+          return if regexp_node.ignore_case? || regexp_node.content == ' '
           return unless determinist_regexp?(regexp_node)
 
           add_offense(regexp_node) do |corrector|

--- a/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_split_regexp_argument_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantSplitRegexpArgument, :config 
     expect_no_offenses("'fooSplitbar'.split(/split/i)")
   end
 
+  it 'accepts when `split` method argument is exactly one spece regexp `/ /`' do
+    expect_no_offenses(<<~RUBY)
+      'foo         bar'.split(/ /)
+    RUBY
+  end
+
   it 'registers an offense when the method is split and correctly removes escaping characters' do
     expect_offense(<<~RUBY)
       'a,b,c'.split(/\\./)
@@ -80,6 +86,17 @@ RSpec.describe RuboCop::Cop::Performance::RedundantSplitRegexpArgument, :config 
 
     expect_correction(<<~RUBY)
       'a,b,c'.split(",")
+    RUBY
+  end
+
+  it 'registers and corrects an offense when `split` method argument is two or more speces regexp `/  /`' do
+    expect_offense(<<~RUBY)
+      'foo         bar'.split(/  /)
+                              ^^^^ Use string as argument instead of regexp.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      'foo         bar'.split("  ")
     RUBY
   end
 end


### PR DESCRIPTION
Fixes #222.

This PR fixes a false positive for `Performance/RedundantSplitRegexpArgument` when `split` method argument is exactly one spece regexp `/ /`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
