### PR TITLE
Fix a false positive for `Style/RedundantEqualityComparisonBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#162](https://github.com/rubocop/rubocop-performance/issues/162): Fix a false positive for `Performance/RedundantBlockCall` when an optional block that is overridden by block variable. ([@koic][])
 * [#36](https://github.com/rubocop/rubocop-performance/issues/36): Fix a false positive for `Performance/ReverseEach` when `each` is called on `reverse` and using the result value. ([@koic][])
+* [#224](https://github.com/rubocop/rubocop-performance/pull/224): Fix a false positive for `Style/RedundantEqualityComparisonBlock` when using one argument with comma separator in block argument. ([@koic][])
 
 ## 1.10.1 (2021-03-02)
 

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -35,7 +35,8 @@ module RuboCop
         IS_A_METHODS = %i[is_a? kind_of?].freeze
 
         def on_block(node)
-          return unless TARGET_METHODS.include?(node.method_name) && node.arguments.one?
+          return unless TARGET_METHODS.include?(node.method_name)
+          return unless one_block_argument?(node.arguments)
 
           block_argument = node.arguments.first
           block_body = node.body
@@ -52,6 +53,10 @@ module RuboCop
         end
 
         private
+
+        def one_block_argument?(block_arguments)
+          block_arguments.one? && !block_arguments.source.include?(',')
+        end
 
         def use_equality_comparison_block?(block_body)
           block_body.send_type? && COMPARISON_METHODS.include?(block_body.method_name)

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       RUBY
     end
 
-    it 'does not register and corrects an offense when using `all?` without `===` comparison block' do
+    it 'does not register an offense when using `all?` without `===` comparison block' do
       expect_no_offenses(<<~RUBY)
         items.all?(other)
       RUBY
     end
 
-    it 'does not register and corrects an offense when using multiple block arguments' do
+    it 'does not register an offense when using multiple block arguments' do
       expect_no_offenses(<<~RUBY)
         items.all? { |key, _value| key == other }
       RUBY
@@ -83,13 +83,19 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       RUBY
     end
 
-    it 'does not register and corrects an offense when using block argument is not used as it is' do
+    it 'does not register an offense when using block argument is not used as it is' do
       expect_no_offenses(<<~RUBY)
         items.all? { |item| item.do_something == other }
       RUBY
     end
 
-    it 'does not register and corrects an offense when using not target methods with `===` comparison block' do
+    it 'does not register an offense when using one argument with comma separator in block argument' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |item,| item == other }
+      RUBY
+    end
+
+    it 'does not register an offense when using not target methods with `===` comparison block' do
       expect_no_offenses(<<~RUBY)
         items.do_something { |item| item == other }
       RUBY


### PR DESCRIPTION
This PR fixes a false positive for `Style/RedundantEqualityComparisonBlock` when using one argument with comma separator in block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
