### PR TITLE
[Fix #225] Fix a false positive for `Style/RedundantEqualityComparisonBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#162](https://github.com/rubocop/rubocop-performance/issues/162): Fix a false positive for `Performance/RedundantBlockCall` when an optional block that is overridden by block variable. ([@koic][])
 * [#36](https://github.com/rubocop/rubocop-performance/issues/36): Fix a false positive for `Performance/ReverseEach` when `each` is called on `reverse` and using the result value. ([@koic][])
 * [#224](https://github.com/rubocop/rubocop-performance/pull/224): Fix a false positive for `Style/RedundantEqualityComparisonBlock` when using one argument with comma separator in block argument. ([@koic][])
+* [#225](https://github.com/rubocop/rubocop-performance/issues/225): Fix a false positive for `Style/RedundantEqualityComparisonBlock` when using `any?` with `===` comparison block and block argument is not used as a receiver for `===`. ([@koic][])
 
 ## 1.10.1 (2021-03-02)
 

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -63,9 +63,13 @@ module RuboCop
         end
 
         def same_block_argument_and_is_a_argument?(block_body, block_argument)
-          return false unless IS_A_METHODS.include?(block_body.method_name)
-
-          block_argument.source == block_body.first_argument.source
+          if block_body.method?(:===)
+            block_argument.source != block_body.children[2].source
+          elsif IS_A_METHODS.include?(block_body.method_name)
+            block_argument.source == block_body.first_argument.source
+          else
+            false
+          end
         end
 
         def new_argument(block_argument, block_body)

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
           items.#{method_name}(Klass)
         RUBY
       end
+
+      it "does not register an offense when using `#{method_name}` with `===` comparison block and" \
+         'block argument is not used as a receiver for `===`' do
+        expect_no_offenses(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item === pattern }
+        RUBY
+      end
     end
 
     it 'registers and corrects an offense when using method chanin and `all?` with `===` comparison block' do


### PR DESCRIPTION
Fixes #225

This PR fixes a false positive for `Style/RedundantEqualityComparisonBlock` when using `any?` with `===` comparison block and block argument is not used as a receiver for `===`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
