### PR TITLE
Mark `Performance/RedundantMerge` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#228](https://github.com/rubocop/rubocop-performance/pull/228): Mark `Performance/RedundantMerge` as unsafe. ([@dvandersluis][])
+
 ## 1.10.2 (2021-03-23)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -220,7 +220,9 @@ Performance/RedundantMerge:
   Description: 'Use Hash#[]=, rather than Hash#merge! with a single key-value pair.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
+  Safe: false
   VersionAdded: '0.36'
+  VersionChanged: '1.11'
   # Max number of key-value pairs to consider an offense
   MaxKeyValuePairs: 2
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1272,16 +1272,19 @@ return value unless regex =~ 'str'
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 0.36
-| -
+| 1.11
 |===
 
 This cop identifies places where `Hash#merge!` can be replaced by
 `Hash#[]=`.
 You can set the maximum number of key-value pairs to consider
 an offense with `MaxKeyValuePairs`.
+
+This cop is marked as unsafe because RuboCop cannot determine if the
+receiver of `merge!` is actually a hash or not.
 
 === Examples
 

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -8,6 +8,9 @@ module RuboCop
       # You can set the maximum number of key-value pairs to consider
       # an offense with `MaxKeyValuePairs`.
       #
+      # This cop is marked as unsafe because RuboCop cannot determine if the
+      # receiver of `merge!` is actually a hash or not.
+      #
       # @example
       #   # bad
       #   hash.merge!(a: 1)


### PR DESCRIPTION
As per https://twitter.com/bbatsov/status/1376631309020315654

`Performance/RedundantMerge` makes the following autocorrection:

```diff
-    @operation_builder.merge!(foobar: [{name: "passed_option"}])
+    @operation_builder[:foobar] = [{name: "passed_option"}]
```

But if `@operation_builder` here is not a hash, this is a bad correction, thus making the cop unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
