### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.4
-          image: circleci/ruby:2.4
-      - rake_default:
           name: Ruby 2.5
           image: circleci/ruby:2.5
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#228](https://github.com/rubocop/rubocop-performance/pull/228): Mark `Performance/RedundantMerge` as unsafe. ([@dvandersluis][])
+* [#232](https://github.com/rubocop/rubocop-performance/pull/232): Drop Ruby 2.4 support. ([@koic][])
 
 ## 1.10.2 (2021-03-23)
 

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -4,37 +4,87 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'TargetRubyVersion <= 2.4', :ruby24 do
-    it "does not register an offense when using `gsub(/\Aprefix/, '')`" do
-      expect_no_offenses(<<~RUBY)
+  context 'when using `\A` as starting pattern' do
+    it "registers an offense and corrects when `gsub(/\Aprefix/, '')`" do
+      expect_offense(<<~RUBY)
         str.gsub(/\\Aprefix/, '')
+            ^^^^ Use `delete_prefix` instead of `gsub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_prefix('prefix')
       RUBY
     end
 
-    it "does not register an offense when using `gsub!(/\Aprefix/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `gsub!(/\Aprefix/, '')`" do
+      expect_offense(<<~RUBY)
         str.gsub!(/\\Aprefix/, '')
+            ^^^^^ Use `delete_prefix!` instead of `gsub!`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_prefix!('prefix')
       RUBY
     end
 
-    it "does not register an offense when using `sub(/\Aprefix/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `sub(/\Aprefix/, '')`" do
+      expect_offense(<<~RUBY)
         str.sub(/\\Aprefix/, '')
+            ^^^ Use `delete_prefix` instead of `sub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_prefix('prefix')
       RUBY
     end
 
-    it "does not register an offense when using `sub!(/\Aprefix/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `sub!(/\Aprefix/, '')`" do
+      expect_offense(<<~RUBY)
         str.sub!(/\\Aprefix/, '')
+            ^^^^ Use `delete_prefix!` instead of `sub!`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_prefix!('prefix')
       RUBY
     end
   end
 
-  context 'TargetRubyVersion >= 2.5', :ruby25 do
-    context 'when using `\A` as starting pattern' do
-      it "registers an offense and corrects when `gsub(/\Aprefix/, '')`" do
+  context 'when using `^` as starting pattern' do
+    context 'when `SafeMultiline: true`' do
+      let(:safe_multiline) { true }
+
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/^prefix/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/^prefix/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/^prefix/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/^prefix/, '')
+        RUBY
+      end
+    end
+
+    context 'when `SafeMultiline: false`' do
+      let(:safe_multiline) { false }
+
+      it 'registers an offense and corrects when using `gsub`' do
         expect_offense(<<~RUBY)
-          str.gsub(/\\Aprefix/, '')
+          str.gsub(/^prefix/, '')
               ^^^^ Use `delete_prefix` instead of `gsub`.
         RUBY
 
@@ -43,9 +93,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `gsub!(/\Aprefix/, '')`" do
+      it 'registers an offense and corrects when using `gsub!`' do
         expect_offense(<<~RUBY)
-          str.gsub!(/\\Aprefix/, '')
+          str.gsub!(/^prefix/, '')
               ^^^^^ Use `delete_prefix!` instead of `gsub!`.
         RUBY
 
@@ -54,9 +104,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `sub(/\Aprefix/, '')`" do
+      it 'registers an offense and corrects when using `sub`' do
         expect_offense(<<~RUBY)
-          str.sub(/\\Aprefix/, '')
+          str.sub(/^prefix/, '')
               ^^^ Use `delete_prefix` instead of `sub`.
         RUBY
 
@@ -65,9 +115,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `sub!(/\Aprefix/, '')`" do
+      it 'registers an offense and corrects when using `sub!`' do
         expect_offense(<<~RUBY)
-          str.sub!(/\\Aprefix/, '')
+          str.sub!(/^prefix/, '')
               ^^^^ Use `delete_prefix!` instead of `sub!`.
         RUBY
 
@@ -76,173 +126,95 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
     end
+  end
 
-    context 'when using `^` as starting pattern' do
-      context 'when `SafeMultiline: true`' do
-        let(:safe_multiline) { true }
-
-        it 'does not register an offense and corrects when using `gsub`' do
-          expect_no_offenses(<<~RUBY)
-            str.gsub(/^prefix/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `gsub!`' do
-          expect_no_offenses(<<~RUBY)
-            str.gsub!(/^prefix/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `sub`' do
-          expect_no_offenses(<<~RUBY)
-            str.sub(/^prefix/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `sub!`' do
-          expect_no_offenses(<<~RUBY)
-            str.sub!(/^prefix/, '')
-          RUBY
-        end
-      end
-
-      context 'when `SafeMultiline: false`' do
-        let(:safe_multiline) { false }
-
-        it 'registers an offense and corrects when using `gsub`' do
-          expect_offense(<<~RUBY)
-            str.gsub(/^prefix/, '')
-                ^^^^ Use `delete_prefix` instead of `gsub`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_prefix('prefix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `gsub!`' do
-          expect_offense(<<~RUBY)
-            str.gsub!(/^prefix/, '')
-                ^^^^^ Use `delete_prefix!` instead of `gsub!`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_prefix!('prefix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `sub`' do
-          expect_offense(<<~RUBY)
-            str.sub(/^prefix/, '')
-                ^^^ Use `delete_prefix` instead of `sub`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_prefix('prefix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `sub!`' do
-          expect_offense(<<~RUBY)
-            str.sub!(/^prefix/, '')
-                ^^^^ Use `delete_prefix!` instead of `sub!`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_prefix!('prefix')
-          RUBY
-        end
-      end
-    end
-
-    context 'when using non-starting pattern' do
-      it 'does not register an offense when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/pattern/, '')
-        RUBY
-      end
-    end
-
-    context 'with starting pattern `\A` and ending pattern `\z`' do
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/\\Aprefix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/\\Aprefix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/\\Aprefix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/\\Aprefix\\z/, '')
-        RUBY
-      end
-    end
-
-    context 'when using a non-blank string as replacement string' do
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/\\Aprefix/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/\\Aprefix/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/\\Aprefix/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/\\Aprefix/, 'foo')
-        RUBY
-      end
-    end
-
-    it 'does not register an offense when using `delete_prefix`' do
+  context 'when using non-starting pattern' do
+    it 'does not register an offense when using `gsub`' do
       expect_no_offenses(<<~RUBY)
-        str.delete_prefix('prefix')
+        str.gsub(/pattern/, '')
       RUBY
     end
 
-    it 'does not register an offense when using `delete_prefix!`' do
+    it 'does not register an offense when using `gsub!`' do
       expect_no_offenses(<<~RUBY)
-        str.delete_prefix!('prefix')
+        str.gsub!(/pattern/, '')
       RUBY
     end
+
+    it 'does not register an offense when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/pattern/, '')
+      RUBY
+    end
+
+    it 'does not register an offense when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/pattern/, '')
+      RUBY
+    end
+  end
+
+  context 'with starting pattern `\A` and ending pattern `\z`' do
+    it 'does not register an offense and corrects when using `gsub`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub(/\\Aprefix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `gsub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub!(/\\Aprefix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/\\Aprefix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/\\Aprefix\\z/, '')
+      RUBY
+    end
+  end
+
+  context 'when using a non-blank string as replacement string' do
+    it 'does not register an offense and corrects when using `gsub`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub(/\\Aprefix/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `gsub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub!(/\\Aprefix/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/\\Aprefix/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/\\Aprefix/, 'foo')
+      RUBY
+    end
+  end
+
+  it 'does not register an offense when using `delete_prefix`' do
+    expect_no_offenses(<<~RUBY)
+      str.delete_prefix('prefix')
+    RUBY
+  end
+
+  it 'does not register an offense when using `delete_prefix!`' do
+    expect_no_offenses(<<~RUBY)
+      str.delete_prefix!('prefix')
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -4,37 +4,87 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'TargetRubyVersion <= 2.4', :ruby24 do
-    it "does not register an offense when using `gsub(/suffix\z/, '')`" do
-      expect_no_offenses(<<~RUBY)
+  context 'when using `\z` as ending pattern' do
+    it "registers an offense and corrects when `gsub(/suffix\z/, '')`" do
+      expect_offense(<<~RUBY)
         str.gsub(/suffix\\z/, '')
+            ^^^^ Use `delete_suffix` instead of `gsub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_suffix('suffix')
       RUBY
     end
 
-    it "does not register an offense when using `gsub!(/suffix\z/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `gsub!(/suffix\z/, '')`" do
+      expect_offense(<<~RUBY)
         str.gsub!(/suffix\\z/, '')
+            ^^^^^ Use `delete_suffix!` instead of `gsub!`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_suffix!('suffix')
       RUBY
     end
 
-    it "does not register an offense when using `sub(/suffix\z/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `sub(/suffix\z/, '')`" do
+      expect_offense(<<~RUBY)
         str.sub(/suffix\\z/, '')
+            ^^^ Use `delete_suffix` instead of `sub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_suffix('suffix')
       RUBY
     end
 
-    it "does not register an offense when using `sub!(/suffix\z/, '')`" do
-      expect_no_offenses(<<~RUBY)
+    it "registers an offense and corrects when `sub!(/suffix\z/, '')`" do
+      expect_offense(<<~RUBY)
         str.sub!(/suffix\\z/, '')
+            ^^^^ Use `delete_suffix!` instead of `sub!`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.delete_suffix!('suffix')
       RUBY
     end
   end
 
-  context 'TargetRubyVersion >= 2.5', :ruby25 do
-    context 'when using `\z` as ending pattern' do
-      it "registers an offense and corrects when `gsub(/suffix\z/, '')`" do
+  context 'when using `$` as ending pattern' do
+    context 'when `SafeMultiline: true`' do
+      let(:safe_multiline) { true }
+
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/suffix$/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/suffix$/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/suffix$/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/suffix$/, '')
+        RUBY
+      end
+    end
+
+    context 'when `SafeMultiline: false`' do
+      let(:safe_multiline) { false }
+
+      it 'registers an offense and corrects when using `gsub`' do
         expect_offense(<<~RUBY)
-          str.gsub(/suffix\\z/, '')
+          str.gsub(/suffix$/, '')
               ^^^^ Use `delete_suffix` instead of `gsub`.
         RUBY
 
@@ -43,9 +93,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `gsub!(/suffix\z/, '')`" do
+      it 'registers an offense and corrects when using `gsub!`' do
         expect_offense(<<~RUBY)
-          str.gsub!(/suffix\\z/, '')
+          str.gsub!(/suffix$/, '')
               ^^^^^ Use `delete_suffix!` instead of `gsub!`.
         RUBY
 
@@ -54,9 +104,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `sub(/suffix\z/, '')`" do
+      it 'registers an offense and corrects when using `sub`' do
         expect_offense(<<~RUBY)
-          str.sub(/suffix\\z/, '')
+          str.sub(/suffix$/, '')
               ^^^ Use `delete_suffix` instead of `sub`.
         RUBY
 
@@ -65,9 +115,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it "registers an offense and corrects when `sub!(/suffix\z/, '')`" do
+      it 'registers an offense and corrects when using `sub!`' do
         expect_offense(<<~RUBY)
-          str.sub!(/suffix\\z/, '')
+          str.sub!(/suffix$/, '')
               ^^^^ Use `delete_suffix!` instead of `sub!`.
         RUBY
 
@@ -76,173 +126,95 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
     end
+  end
 
-    context 'when using `$` as ending pattern' do
-      context 'when `SafeMultiline: true`' do
-        let(:safe_multiline) { true }
-
-        it 'does not register an offense and corrects when using `gsub`' do
-          expect_no_offenses(<<~RUBY)
-            str.gsub(/suffix$/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `gsub!`' do
-          expect_no_offenses(<<~RUBY)
-            str.gsub!(/suffix$/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `sub`' do
-          expect_no_offenses(<<~RUBY)
-            str.sub(/suffix$/, '')
-          RUBY
-        end
-
-        it 'does not register an offense and corrects when using `sub!`' do
-          expect_no_offenses(<<~RUBY)
-            str.sub!(/suffix$/, '')
-          RUBY
-        end
-      end
-
-      context 'when `SafeMultiline: false`' do
-        let(:safe_multiline) { false }
-
-        it 'registers an offense and corrects when using `gsub`' do
-          expect_offense(<<~RUBY)
-            str.gsub(/suffix$/, '')
-                ^^^^ Use `delete_suffix` instead of `gsub`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_suffix('suffix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `gsub!`' do
-          expect_offense(<<~RUBY)
-            str.gsub!(/suffix$/, '')
-                ^^^^^ Use `delete_suffix!` instead of `gsub!`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_suffix!('suffix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `sub`' do
-          expect_offense(<<~RUBY)
-            str.sub(/suffix$/, '')
-                ^^^ Use `delete_suffix` instead of `sub`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_suffix('suffix')
-          RUBY
-        end
-
-        it 'registers an offense and corrects when using `sub!`' do
-          expect_offense(<<~RUBY)
-            str.sub!(/suffix$/, '')
-                ^^^^ Use `delete_suffix!` instead of `sub!`.
-          RUBY
-
-          expect_correction(<<~RUBY)
-            str.delete_suffix!('suffix')
-          RUBY
-        end
-      end
-    end
-
-    context 'when using non-ending pattern' do
-      it 'does not register an offense when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/pattern/, '')
-        RUBY
-      end
-
-      it 'does not register an offense when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/pattern/, '')
-        RUBY
-      end
-    end
-
-    context 'with starting pattern `\A` and ending pattern `\z`' do
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/\\Asuffix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/\\Asuffix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/\\Asuffix\\z/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/\\Asuffix\\z/, '')
-        RUBY
-      end
-    end
-
-    context 'when using a non-blank string as replacement string' do
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/suffix\\z/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/suffix\\z/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/suffix\\z/, 'foo')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/suffix\\z/, 'foo')
-        RUBY
-      end
-    end
-
-    it 'does not register an offense when using `delete_suffix`' do
+  context 'when using non-ending pattern' do
+    it 'does not register an offense when using `gsub`' do
       expect_no_offenses(<<~RUBY)
-        str.delete_suffix('suffix')
+        str.gsub(/pattern/, '')
       RUBY
     end
 
-    it 'does not register an offense when using `delete_suffix!`' do
+    it 'does not register an offense when using `gsub!`' do
       expect_no_offenses(<<~RUBY)
-        str.delete_suffix!('suffix')
+        str.gsub!(/pattern/, '')
       RUBY
     end
+
+    it 'does not register an offense when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/pattern/, '')
+      RUBY
+    end
+
+    it 'does not register an offense when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/pattern/, '')
+      RUBY
+    end
+  end
+
+  context 'with starting pattern `\A` and ending pattern `\z`' do
+    it 'does not register an offense and corrects when using `gsub`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub(/\\Asuffix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `gsub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub!(/\\Asuffix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/\\Asuffix\\z/, '')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/\\Asuffix\\z/, '')
+      RUBY
+    end
+  end
+
+  context 'when using a non-blank string as replacement string' do
+    it 'does not register an offense and corrects when using `gsub`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub(/suffix\\z/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `gsub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.gsub!(/suffix\\z/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub(/suffix\\z/, 'foo')
+      RUBY
+    end
+
+    it 'does not register an offense and corrects when using `sub!`' do
+      expect_no_offenses(<<~RUBY)
+        str.sub!(/suffix\\z/, 'foo')
+      RUBY
+    end
+  end
+
+  it 'does not register an offense when using `delete_suffix`' do
+    expect_no_offenses(<<~RUBY)
+      str.delete_suffix('suffix')
+    RUBY
+  end
+
+  it 'does not register an offense when using `delete_suffix!`' do
+    expect_no_offenses(<<~RUBY)
+      str.delete_suffix!('suffix')
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -1,120 +1,109 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :config do
-  context 'TargetRubyVersion >= 2.5', :ruby25 do
-    RuboCop::Cop::Performance::RedundantEqualityComparisonBlock::TARGET_METHODS.each do |method_name|
-      it "registers and corrects an offense when using `#{method_name}` with `===` comparison block" do
-        expect_offense(<<~RUBY, method_name: method_name)
-          items.#{method_name} { |item| pattern === item }
-                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(pattern)` instead of block.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          items.#{method_name}(pattern)
-        RUBY
-      end
-
-      it "registers and corrects an offense when using `#{method_name}` with `==` comparison block" do
-        expect_offense(<<~RUBY, method_name: method_name)
-          items.#{method_name} { |item| item == other }
-                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(other)` instead of block.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          items.#{method_name}(other)
-        RUBY
-      end
-
-      it "registers and corrects an offense when using `#{method_name}` with `is_a?` comparison block" do
-        expect_offense(<<~RUBY, method_name: method_name)
-          items.#{method_name} { |item| item.is_a?(Klass) }
-                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          items.#{method_name}(Klass)
-        RUBY
-      end
-
-      it "registers and corrects an offense when using `#{method_name}` with `kind_of?` comparison block" do
-        expect_offense(<<~RUBY, method_name: method_name)
-          items.#{method_name} { |item| item.kind_of?(Klass) }
-                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          items.#{method_name}(Klass)
-        RUBY
-      end
-
-      it "does not register an offense when using `#{method_name}` with `===` comparison block and" \
-         'block argument is not used as a receiver for `===`' do
-        expect_no_offenses(<<~RUBY, method_name: method_name)
-          items.#{method_name} { |item| item === pattern }
-        RUBY
-      end
-    end
-
-    it 'registers and corrects an offense when using method chanin and `all?` with `===` comparison block' do
-      expect_offense(<<~RUBY)
-        items.do_something.all? { |item| item == other }
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `all?(other)` instead of block.
+  RuboCop::Cop::Performance::RedundantEqualityComparisonBlock::TARGET_METHODS.each do |method_name|
+    it "registers and corrects an offense when using `#{method_name}` with `===` comparison block" do
+      expect_offense(<<~RUBY, method_name: method_name)
+        items.#{method_name} { |item| pattern === item }
+              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(pattern)` instead of block.
       RUBY
 
       expect_correction(<<~RUBY)
-        items.do_something.all?(other)
+        items.#{method_name}(pattern)
       RUBY
     end
 
-    it 'does not register an offense when using `all?` without `===` comparison block' do
-      expect_no_offenses(<<~RUBY)
-        items.all?(other)
+    it "registers and corrects an offense when using `#{method_name}` with `==` comparison block" do
+      expect_offense(<<~RUBY, method_name: method_name)
+        items.#{method_name} { |item| item == other }
+              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(other)` instead of block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        items.#{method_name}(other)
       RUBY
     end
 
-    it 'does not register an offense when using multiple block arguments' do
-      expect_no_offenses(<<~RUBY)
-        items.all? { |key, _value| key == other }
+    it "registers and corrects an offense when using `#{method_name}` with `is_a?` comparison block" do
+      expect_offense(<<~RUBY, method_name: method_name)
+        items.#{method_name} { |item| item.is_a?(Klass) }
+              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        items.#{method_name}(Klass)
       RUBY
     end
 
-    it 'does not register an offense when using block argument is used for an argument of `is_a`' do
-      expect_no_offenses(<<~RUBY)
-        klasses.all? { |klass| item.is_a?(klass) }
+    it "registers and corrects an offense when using `#{method_name}` with `kind_of?` comparison block" do
+      expect_offense(<<~RUBY, method_name: method_name)
+        items.#{method_name} { |item| item.kind_of?(Klass) }
+              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        items.#{method_name}(Klass)
       RUBY
     end
 
-    it 'does not register an offense when using block argument is used for an argument of `kind_of?`' do
-      expect_no_offenses(<<~RUBY)
-        klasses.all? { |klass| item.kind_of?(klass) }
-      RUBY
-    end
-
-    it 'does not register an offense when using block argument is not used as it is' do
-      expect_no_offenses(<<~RUBY)
-        items.all? { |item| item.do_something == other }
-      RUBY
-    end
-
-    it 'does not register an offense when using one argument with comma separator in block argument' do
-      expect_no_offenses(<<~RUBY)
-        items.all? { |item,| item == other }
-      RUBY
-    end
-
-    it 'does not register an offense when using not target methods with `===` comparison block' do
-      expect_no_offenses(<<~RUBY)
-        items.do_something { |item| item == other }
+    it "does not register an offense when using `#{method_name}` with `===` comparison block and" \
+       'block argument is not used as a receiver for `===`' do
+      expect_no_offenses(<<~RUBY, method_name: method_name)
+        items.#{method_name} { |item| item === pattern }
       RUBY
     end
   end
 
-  context 'TargetRubyVersion <= 2.4', :ruby24 do
-    # Ruby 2.4 does not support `items.all?(Klass)`.
-    it 'does not register an offense when using `all?` with `is_a?` comparison block' do
-      expect_no_offenses(<<~RUBY)
-        items.all? { |item| item.is_a?(Klass) }
-      RUBY
-    end
+  it 'registers and corrects an offense when using method chanin and `all?` with `===` comparison block' do
+    expect_offense(<<~RUBY)
+      items.do_something.all? { |item| item == other }
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `all?(other)` instead of block.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      items.do_something.all?(other)
+    RUBY
+  end
+
+  it 'does not register an offense when using `all?` without `===` comparison block' do
+    expect_no_offenses(<<~RUBY)
+      items.all?(other)
+    RUBY
+  end
+
+  it 'does not register an offense when using multiple block arguments' do
+    expect_no_offenses(<<~RUBY)
+      items.all? { |key, _value| key == other }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is used for an argument of `is_a`' do
+    expect_no_offenses(<<~RUBY)
+      klasses.all? { |klass| item.is_a?(klass) }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is used for an argument of `kind_of?`' do
+    expect_no_offenses(<<~RUBY)
+      klasses.all? { |klass| item.kind_of?(klass) }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is not used as it is' do
+    expect_no_offenses(<<~RUBY)
+      items.all? { |item| item.do_something == other }
+    RUBY
+  end
+
+  it 'does not register an offense when using one argument with comma separator in block argument' do
+    expect_no_offenses(<<~RUBY)
+      items.all? { |item,| item == other }
+    RUBY
+  end
+
+  it 'does not register an offense when using not target methods with `===` comparison block' do
+    expect_no_offenses(<<~RUBY)
+      items.do_something { |item| item == other }
+    RUBY
   end
 end

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -46,17 +46,15 @@ task documentation_syntax_check: :yard_for_generate_documentation do
     end
 
     examples.to_a.each do |example|
-      begin
-        buffer = Parser::Source::Buffer.new('<code>', 1)
-        buffer.source = example.text
-        parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
-        parser.diagnostics.all_errors_are_fatal = true
-        parser.parse(buffer)
-      rescue Parser::SyntaxError => e
-        path = example.object.file
-        puts "#{path}: Syntax Error in an example. #{e}"
-        ok = false
-      end
+      buffer = Parser::Source::Buffer.new('<code>', 1)
+      buffer.source = example.text
+      parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
+      parser.diagnostics.all_errors_are_fatal = true
+      parser.parse(buffer)
+    rescue Parser::SyntaxError => e
+      path = example.object.file
+      puts "#{path}: Syntax Error in an example. #{e}"
+      ok = false
     end
   end
   abort unless ok


### PR DESCRIPTION
Follow https://github.com/rubocop/rubocop/pull/9648.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
