### PR TITLE
[Fix #230] Fix a false positive for `Performance/ChainArrayAllocation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#229](https://github.com/rubocop/rubocop-performance/pull/229): Add new `Add `Performance/MapCompact` cop` cop. ([@koic][])
 
+### Bug fixes
+
+* [#230](https://github.com/rubocop/rubocop-performance/issues/230): Fix a false positive for `Performance/ChainArrayAllocation` when using `Enumerable#lazy`. ([@koic][])
+
 ### Changes
 
 * [#228](https://github.com/rubocop/rubocop-performance/pull/228): Mark `Performance/RedundantMerge` as unsafe. ([@dvandersluis][])

--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -63,6 +63,8 @@ module RuboCop
 
         def on_send(node)
           chain_array_allocation?(node) do |fm, sm|
+            return if node.each_descendant(:send).any? { |descendant| descendant.method?(:lazy) }
+
             range = range_between(node.loc.dot.begin_pos, node.source_range.end_pos)
 
             add_offense(range, message: format(MSG, method: fm, second_method: sm))

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
       RUBY
     end
   end
+
+  describe 'when using `Enumerable#lazy`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        some_array.lazy.map(&:some_obj_method).reject(&:nil?).first
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #230.

This PR fixes a false positive for `Performance/ChainArrayAllocation` when using `Enumerable#lazy`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
