### PR TITLE
Require RuboCop 1.7 or higher due to support obsoletion configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#228](https://github.com/rubocop/rubocop-performance/pull/228): Mark `Performance/RedundantMerge` as unsafe. ([@dvandersluis][])
 * [#232](https://github.com/rubocop/rubocop-performance/pull/232): Drop Ruby 2.4 support. ([@koic][])
+* [#235](https://github.com/rubocop/rubocop-performance/pull/235): Require RuboCop 1.7 or higher. ([@koic][])
 
 ## 1.10.2 (2021-03-23)
 

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -1,0 +1,7 @@
+#
+# Configuration for obsoletion.
+#
+# See: https://docs.rubocop.org/rubocop/extensions.html#config-obsoletions
+#
+extracted:
+  Performance/*: ~

--- a/lib/rubocop/performance.rb
+++ b/lib/rubocop/performance.rb
@@ -8,5 +8,7 @@ module RuboCop
     CONFIG = YAML.safe_load(CONFIG_DEFAULT.read).freeze
 
     private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+
+    ::RuboCop::ConfigObsoletion.files << PROJECT_ROOT.join('config', 'obsoletion.yml')
   end
 end

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-performance/issues'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 0.90.0', '< 2.0')
+  s.add_runtime_dependency('rubocop', '>= 1.7.0', '< 2.0')
   s.add_runtime_dependency('rubocop-ast', '>= 0.4.0')
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'RuboCop Performance Project', type: :feature do
   describe 'default configuration file' do
     subject(:config) { RuboCop::ConfigLoader.load_file('config/default.yml') }
 
-    before do
-      allow_any_instance_of(RuboCop::Config).to receive(:loaded_features).and_return('rubocop-performance') # rubocop:disable RSpec/AnyInstance
-    end
-
     let(:registry) { RuboCop::Cop::Registry.global }
     let(:cop_names) do
       registry.with_department(:Performance).cops.map(&:cop_name)


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop/pull/9206 and https://github.com/rubocop-hq/rubocop/pull/9143.

This PR requires RuboCop 1.7 or higher due to support obsoletion configuration and reverts https://github.com/rubocop/rubocop-performance/commit/0e59891.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
