### PR TITLE
[Fix #236] Fix an incorrect auto-correct for `Performance/MapCompact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#236](https://github.com/rubocop/rubocop-performance/issues/236): Fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line leading dot method calls. ([@koic][])
+
 ## 1.11.0 (2021-04-22)
 
 ### New features

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -56,7 +56,19 @@ module RuboCop
           add_offense(range) do |corrector|
             corrector.replace(map_node.loc.selector, 'filter_map')
             corrector.remove(compact_loc.dot)
-            corrector.remove(compact_loc.selector)
+            corrector.remove(compact_method_range(node))
+          end
+        end
+
+        private
+
+        def compact_method_range(compact_node)
+          compact_method_range = compact_node.loc.selector
+
+          if compact_node.multiline?
+            range_by_whole_lines(compact_method_range, include_final_newline: true)
+          else
+            compact_method_range
           end
         end
       end

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -46,6 +46,46 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using `map.compact.first` with single-line method calls' do
+      expect_offense(<<~RUBY)
+        collection.map { |item| item.do_something }.compact.first
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map { |item| item.do_something }.first
+      RUBY
+    end
+
+    it 'registers an offense when using `map.compact.first` with multi-line leading dot method calls' do
+      expect_offense(<<~RUBY)
+        collection
+          .map { |item| item.do_something }
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .compact
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection
+          .filter_map { |item| item.do_something }
+          .first
+      RUBY
+    end
+
+    it 'registers an offense when using `map.compact.first` and there is a line break after `map.compact`' do
+      expect_offense(<<~RUBY)
+        collection.map { |item| item.do_something }.compact
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map { |item| item.do_something }
+          .first
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.map(&:do_something).compact!`' do
       expect_no_offenses(<<~RUBY)
         collection.map(&:do_something).compact!


### PR DESCRIPTION
Fixes #236.

This PR fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line leading dot method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
