### PR TITLE
[Fix #238] Fix an incorrect auto-correct for `Performance/MapCompact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#238](https://github.com/rubocop/rubocop-performance/issues/238): Fix an incorrect auto-correct for `Performance/MapCompact` when invoking a method after `map { ... }.compact` on the same line. ([@koic][])
+
 ## 1.11.1 (2021-05-02)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -63,13 +63,19 @@ module RuboCop
         private
 
         def compact_method_range(compact_node)
+          chained_method = compact_node.parent
           compact_method_range = compact_node.loc.selector
 
-          if compact_node.multiline?
+          if compact_node.multiline? &&
+             chained_method && !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
             range_by_whole_lines(compact_method_range, include_final_newline: true)
           else
             compact_method_range
           end
+        end
+
+        def invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
+          compact_node.loc.selector.line == chained_method.loc.selector.line
         end
       end
     end

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -86,6 +86,32 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using `map { ... }.compact`' do
+      expect_offense(<<~RUBY)
+        collection.map { |item|
+                   ^^^^^^^^^^^^ Use `filter_map` instead.
+        }.compact
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map { |item|
+        }
+      RUBY
+    end
+
+    it 'registers an offense when invoking a method after `map { ... }.compact`' do
+      expect_offense(<<~RUBY)
+        collection.map { |item|
+                   ^^^^^^^^^^^^ Use `filter_map` instead.
+        }.compact.do_something
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map { |item|
+        }.do_something
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.map(&:do_something).compact!`' do
       expect_no_offenses(<<~RUBY)
         collection.map(&:do_something).compact!


### PR DESCRIPTION
Fixes #238.

This PR fixes an incorrect auto-correct for `Performance/MapCompact` when invoking a method after `map { ... }.compact` on the same line.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
