### PR TITLE
[Fix #240] Disable `Performance/Casecmp` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#240](https://github.com/rubocop/rubocop-performance/issues/240): Retire `Performance/Casecmp` cop. ([@parkerfinch][])
+
 ## 1.11.2 (2021-05-05)
 
 ### Bug fixes
@@ -271,3 +275,4 @@
 [@dvandersluis]: https://github.com/dvandersluis
 [@ghiculescu]: https://github.com/ghiculescu
 [@mfbmina]: https://github.com/mfbmina
+[@parkerfinch]: https://github.com/parkerfinch

--- a/config/default.yml
+++ b/config/default.yml
@@ -52,7 +52,7 @@ Performance/Casecmp:
   Description: >-
              Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdowncase---code'
-  Enabled: true
+  Enabled: false
   Safe: false
   VersionAdded: '0.36'
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -283,7 +283,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
-| Enabled
+| Disabled
 | No
 | Yes (Unsafe)
 | 0.36
@@ -292,8 +292,12 @@ end
 
 This cop identifies places where a case-insensitive string comparison
 can better be implemented using `casecmp`.
-This cop is unsafe because `String#casecmp` and `String#casecmp?` behave
-differently when using Non-ASCII characters.
+
+This cop is disabled by default because `String#casecmp` only works with
+ASCII characters. See https://github.com/rubocop/rubocop/issues/9753.
+
+If you are working only with ASCII characters, then this cop can be
+safely enabled.
 
 === Examples
 

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -5,8 +5,12 @@ module RuboCop
     module Performance
       # This cop identifies places where a case-insensitive string comparison
       # can better be implemented using `casecmp`.
-      # This cop is unsafe because `String#casecmp` and `String#casecmp?` behave
-      # differently when using Non-ASCII characters.
+      #
+      # This cop is disabled by default because `String#casecmp` only works with
+      # ASCII characters. See https://github.com/rubocop/rubocop/issues/9753.
+      #
+      # If you are working only with ASCII characters, then this cop can be
+      # safely enabled.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This cop suggests an incorrect fix when code involves non-ASCII
characters. Disabling it by default makes this risky behavior opt-in
rather than opt-out.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. (N/A)
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
