### PR TITLE
[Fix #242] Fix an error for `Performance/MapCompact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#242](https://github.com/rubocop/rubocop-performance/issues/242): Fix an error for `Performance/MapCompact` when using multiline `map { ... }.compact` and assigning to return value. ([@koic][])
+
 ## 1.11.2 (2021-05-05)
 
 ### Bug fixes

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -66,8 +66,8 @@ module RuboCop
           chained_method = compact_node.parent
           compact_method_range = compact_node.loc.selector
 
-          if compact_node.multiline? &&
-             chained_method && !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
+          if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) &&
+             !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
             range_by_whole_lines(compact_method_range, include_final_newline: true)
           else
             compact_method_range

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -112,6 +112,19 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using multiline `map { ... }.compact` and assigning to return value' do
+      expect_offense(<<~RUBY)
+        ret = collection.map do |item|
+                         ^^^^^^^^^^^^^ Use `filter_map` instead.
+        end.compact
+      RUBY
+
+      expect_correction(<<~RUBY)
+        ret = collection.filter_map do |item|
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.map(&:do_something).compact!`' do
       expect_no_offenses(<<~RUBY)
         collection.map(&:do_something).compact!


### PR DESCRIPTION
Fixes #242.

This PR fixes an error for `Performance/MapCompact` when using multiline `map { ... }.compact` and assigning to return value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
