### PR TITLE
Update the doc for `Performance/MapCompact`

### DIFF
--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1076,6 +1076,7 @@ ary.collect(&:foo).compact
 # good
 ary.filter_map(&:foo)
 ary.map(&:foo).compact!
+ary.compact.map(&:foo)
 ----
 
 == Performance/MethodObjectAsBlock

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -23,6 +23,7 @@ module RuboCop
       #   # good
       #   ary.filter_map(&:foo)
       #   ary.map(&:foo).compact!
+      #   ary.compact.map(&:foo)
       #
       class MapCompact < Base
         include RangeHelp

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -136,6 +136,12 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'does not register an offense when using `collection.compact.map(&:do_something)`' do
+      expect_no_offenses(<<~RUBY)
+        collection.compact.map(&:do_something)
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.not_map_method(&:do_something).compact`' do
       expect_no_offenses(<<~RUBY)
         collection.not_map_method(&:do_something).compact


### PR DESCRIPTION
Follow https://github.com/rails/rails/pull/42090#discussion_r621864689

This PR adds an example to the doc (and test) that `compact.map` and `filter_map` are not same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
