### PR TITLE
[Fix #245] Mark `Performance/DeletePrefix` and `Performance/DeleteSuffix` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#245](https://github.com/rubocop/rubocop-performance/issues/245): Mark `Performance/DeletePrefix` and `Performance/DeleteSuffix` as unsafe. ([@koic][])
+
 ## 1.11.3 (2021-05-06)
 
 ### Bug fixes

--- a/config/default.yml
+++ b/config/default.yml
@@ -96,14 +96,18 @@ Performance/Count:
 Performance/DeletePrefix:
   Description: 'Use `delete_prefix` instead of `gsub`.'
   Enabled: true
+  Safe: false
   SafeMultiline: true
   VersionAdded: '1.6'
+  VersionChanged: '1.12'
 
 Performance/DeleteSuffix:
   Description: 'Use `delete_suffix` instead of `gsub`.'
   Enabled: true
+  Safe: false
   SafeMultiline: true
   VersionAdded: '1.6'
+  VersionChanged: '1.12'
 
 Performance/Detect:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -548,16 +548,17 @@ NOTE: Required Ruby version: 2.5
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.6
-| -
+| 1.12
 |===
 
 In Ruby 2.5, `String#delete_prefix` has been added.
 
 This cop identifies places where `gsub(/\Aprefix/, '')` and `sub(/\Aprefix/, '')`
 can be replaced by `delete_prefix('prefix')`.
+It is marked as unsafe by default because `Pathname` has `sub` but not `delete_prefix`.
 
 This cop has `SafeMultiline` configuration option that `true` by default because
 `^prefix` is unsafe as it will behave incompatible with `delete_prefix`
@@ -621,16 +622,17 @@ NOTE: Required Ruby version: 2.5
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.6
-| -
+| 1.12
 |===
 
 In Ruby 2.5, `String#delete_suffix` has been added.
 
 This cop identifies places where `gsub(/suffix\z/, '')` and `sub(/suffix\z/, '')`
 can be replaced by `delete_suffix('suffix')`.
+It is marked as unsafe by default because `Pathname` has `sub` but not `delete_suffix`.
 
 This cop has `SafeMultiline` configuration option that `true` by default because
 `suffix$` is unsafe as it will behave incompatible with `delete_suffix?`

--- a/lib/rubocop/cop/performance/delete_prefix.rb
+++ b/lib/rubocop/cop/performance/delete_prefix.rb
@@ -7,6 +7,7 @@ module RuboCop
       #
       # This cop identifies places where `gsub(/\Aprefix/, '')` and `sub(/\Aprefix/, '')`
       # can be replaced by `delete_prefix('prefix')`.
+      # It is marked as unsafe by default because `Pathname` has `sub` but not `delete_prefix`.
       #
       # This cop has `SafeMultiline` configuration option that `true` by default because
       # `^prefix` is unsafe as it will behave incompatible with `delete_prefix`

--- a/lib/rubocop/cop/performance/delete_suffix.rb
+++ b/lib/rubocop/cop/performance/delete_suffix.rb
@@ -7,6 +7,7 @@ module RuboCop
       #
       # This cop identifies places where `gsub(/suffix\z/, '')` and `sub(/suffix\z/, '')`
       # can be replaced by `delete_suffix('suffix')`.
+      # It is marked as unsafe by default because `Pathname` has `sub` but not `delete_suffix`.
       #
       # This cop has `SafeMultiline` configuration option that `true` by default because
       # `suffix$` is unsafe as it will behave incompatible with `delete_suffix?`


### PR DESCRIPTION
Fixes #245.

This PR marks `Performance/DeletePrefix` and `Performance/DeleteSuffix` as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
