### PR TITLE
[Fix #247] Fix an incorrect auto-correct for `Performance/MapCompact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#247](https://github.com/rubocop/rubocop-performance/issues/247): Fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line trailing dot method calls. ([@koic][])
+
 ### Changes
 
 * [#245](https://github.com/rubocop/rubocop-performance/issues/245): Mark `Performance/DeletePrefix` and `Performance/DeleteSuffix` as unsafe. ([@koic][])

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -56,23 +56,24 @@ module RuboCop
 
           add_offense(range) do |corrector|
             corrector.replace(map_node.loc.selector, 'filter_map')
-            corrector.remove(compact_loc.dot)
-            corrector.remove(compact_method_range(node))
+            remove_compact_method(corrector, node)
           end
         end
 
         private
 
-        def compact_method_range(compact_node)
+        def remove_compact_method(corrector, compact_node)
           chained_method = compact_node.parent
           compact_method_range = compact_node.loc.selector
 
           if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) &&
              !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
-            range_by_whole_lines(compact_method_range, include_final_newline: true)
+            compact_method_range = range_by_whole_lines(compact_method_range, include_final_newline: true)
           else
-            compact_method_range
+            corrector.remove(compact_node.loc.dot)
           end
+
+          corrector.remove(compact_method_range)
         end
 
         def invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using `map.compact.first` with multi-line trailing dot method calls' do
+      expect_offense(<<~RUBY)
+        collection.
+          map { |item| item.do_something }.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          compact.
+          first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.
+          filter_map { |item| item.do_something }.
+          first
+      RUBY
+    end
+
     it 'registers an offense when using `map.compact.first` and there is a line break after `map.compact`' do
       expect_offense(<<~RUBY)
         collection.map { |item| item.do_something }.compact


### PR DESCRIPTION
Fixes #247.

This PR fixes an incorrect auto-correct for `Performance/MapCompact` when using multi-line trailing dot method calls.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
