### PR TITLE
[Fix #249] Fix a false positive for `Performance/RedundantStringChars`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#247](https://github.com/rubocop/rubocop-performance/issues/247): Fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line trailing dot method calls. ([@koic][])
+* [#249](https://github.com/rubocop/rubocop-performance/issues/249): Fix a false positive for `Performance/RedundantStringChars` when using `str.chars.last` and `str.chars.drop`. ([@koic][])
 
 ### Changes
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1447,28 +1447,28 @@ str[0..2].chars
 # bad
 str.chars.first
 str.chars.first(2)
-str.chars.last
-str.chars.last(2)
 
 # good
 str[0]
 str[0...2].chars
-str[-1]
-str[-2..-1].chars
 
 # bad
 str.chars.take(2)
-str.chars.drop(2)
 str.chars.length
 str.chars.size
 str.chars.empty?
 
 # good
 str[0...2].chars
-str[2..-1].chars
 str.length
 str.size
 str.empty?
+
+# For example, if the receiver is a blank string, it will be incompatible.
+# If a negative value is specified for the receiver, `nil` is returned.
+str.chars.last    # Incompatible with `str[-1]`.
+str.chars.last(2) # Incompatible with `str[-2..-1].chars`.
+str.chars.drop(2) # Incompatible with `str[2..-1].chars`.
 ----
 
 == Performance/RegexpMatch

--- a/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
@@ -45,25 +45,15 @@ RSpec.describe RuboCop::Cop::Performance::RedundantStringChars, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using `str.chars.last`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `str.chars.last`' do
+    expect_no_offenses(<<~RUBY)
       str.chars.last
-          ^^^^^^^^^^ Use `[-1]` instead of `chars.last`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      str[-1]
     RUBY
   end
 
-  it 'registers an offense and corrects when using `str.chars.last(2)`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `str.chars.last(2)`' do
+    expect_no_offenses(<<~RUBY)
       str.chars.last(2)
-          ^^^^^^^^^^^^^ Use `[-2..-1].chars` instead of `chars.last(2)`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      str[-2..-1].chars
     RUBY
   end
 
@@ -78,14 +68,9 @@ RSpec.describe RuboCop::Cop::Performance::RedundantStringChars, :config do
     RUBY
   end
 
-  it 'registers an offense and corrects when using `str.chars.drop(2)`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `str.chars.drop(2)`' do
+    expect_no_offenses(<<~RUBY)
       str.chars.drop(2)
-          ^^^^^^^^^^^^^ Use `[2..-1].chars` instead of `chars.drop(2)`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      str[2..-1].chars
     RUBY
   end
 


### PR DESCRIPTION
Fixes #249.

This PR fixes a false positive for `Performance/RedundantStringChars` when using `str.chars.last` and `str.chars.drop`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
