### PR TITLE
[Fix #249] Mark `Performance/RedundantStringChars` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#245](https://github.com/rubocop/rubocop-performance/issues/245): Mark `Performance/DeletePrefix` and `Performance/DeleteSuffix` as unsafe. ([@koic][])
+* [#249](https://github.com/rubocop/rubocop-performance/issues/249): Mark `Performance/RedundantStringChars` as unsafe. ([@tejasbubane][])
 
 ## 1.11.3 (2021-05-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -248,8 +248,10 @@ Performance/RedundantSplitRegexpArgument:
 
 Performance/RedundantStringChars:
   Description: 'Checks for redundant `String#chars`.'
+  Safe: false
   Enabled: 'pending'
   VersionAdded: '1.7'
+  VersionChanged: '1.12'
 
 Performance/RegexpMatch:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1425,10 +1425,10 @@ a deterministic regexp to a string.
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.7
-| -
+| 1.12
 |===
 
 This cop checks for redundant `String#chars`.

--- a/lib/rubocop/cop/performance/redundant_string_chars.rb
+++ b/lib/rubocop/cop/performance/redundant_string_chars.rb
@@ -4,6 +4,9 @@ module RuboCop
   module Cop
     module Performance
       # This cop checks for redundant `String#chars`.
+      # It is marked unsafe by default because suggested autocorrections like
+      # `str[-2..-1]` could return `nil` when `str` holds short values and
+      # `.chars` on that can raise error - resulting in unsafe behaviour.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Closes #249

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/