### PR TITLE
[Fix #252] Fix an incorrect auto-correct for `Performance/UnfreezeString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#247](https://github.com/rubocop/rubocop-performance/issues/247): Fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line trailing dot method calls. ([@koic][])
 * [#249](https://github.com/rubocop/rubocop-performance/issues/249): Fix a false positive for `Performance/RedundantStringChars` when using `str.chars.last` and `str.chars.drop`. ([@koic][])
+* [#252](https://github.com/rubocop/rubocop-performance/issues/252): Fix an incorrect auto-correct for `Performance/UnfreezeString` when invoking a method after `String.new` with a string. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/unfreeze_string.rb
+++ b/lib/rubocop/cop/performance/unfreeze_string.rb
@@ -45,7 +45,10 @@ module RuboCop
           return unless dup_string?(node) || string_new?(node)
 
           add_offense(node) do |corrector|
-            corrector.replace(node, "+#{string_value(node)}")
+            string_value = "+#{string_value(node)}"
+            string_value = "(#{string_value})" if node.parent&.send_type?
+
+            corrector.replace(node, string_value)
           end
         end
 

--- a/spec/rubocop/cop/performance/unfreeze_string_spec.rb
+++ b/spec/rubocop/cop/performance/unfreeze_string_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
     RUBY
   end
 
+  it 'registers an offense and corrects when invoking a method after `String.new` with a string' do
+    expect_offense(<<~RUBY)
+      String.new('foo').force_encoding(Encoding::ASCII)
+      ^^^^^^^^^^^^^^^^^ Use unary plus to get an unfrozen string literal.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (+'foo').force_encoding(Encoding::ASCII)
+    RUBY
+  end
+
   it 'accepts an empty string with unary plus operator' do
     expect_no_offenses(<<~RUBY)
       +""


### PR DESCRIPTION
Fixes #252.

This PR fixes an incorrect auto-correct for `Performance/UnfreezeString` when invoking a method after `String.new` with a string.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
