### PR TITLE
[Fix #255] Fix a false positive for `Performance/RedundantEqualityComparisonBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#255](https://github.com/rubocop/rubocop-performance/issues/255): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using block argument is used for an argument of operand. ([@koic][])
+
 ## 1.11.4 (2021-07-07)
 
 ### Bug fixes

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -106,4 +106,28 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       items.do_something { |item| item == other }
     RUBY
   end
+
+  it 'does not register an offense when using block argument is used for an argument of RHS operand' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { |item| item == do_something(item) }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is used for a argument of LHS operand' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { |item| do_something(item) == item }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is used for a nested argument of RHS operand' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { |item| item == do_something[0..item] }
+    RUBY
+  end
+
+  it 'does not register an offense when using block argument is used for a nested argument of LHS operand' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { |item| do_something[0..item] == item }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #255.

This PR fixes a false positive for `Performance/RedundantEqualityComparisonBlock` when using block argument is used for an argument of operand.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
