### PR TITLE
[Fix #257] Fix an incorrect auto-correct for `Performance/MapCompact`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#255](https://github.com/rubocop/rubocop-performance/issues/255): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when using block argument is used for an argument of operand. ([@koic][])
+* [#257](https://github.com/rubocop/rubocop-performance/issues/257): Fix an incorrect auto-correct for `Performance/MapCompact` when using multi-line `collection.map { ... }.compact` as a method argument. ([@koic][])
 
 ## 1.11.4 (2021-07-07)
 

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -66,7 +66,7 @@ module RuboCop
           chained_method = compact_node.parent
           compact_method_range = compact_node.loc.selector
 
-          if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) &&
+          if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) && chained_method.dot? &&
              !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
             compact_method_range = range_by_whole_lines(compact_method_range, include_final_newline: true)
           else

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -128,6 +128,23 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using multi-line `collection.map { ... }.compact` as a method argument' do
+      expect_offense(<<~RUBY)
+        do_something(
+          collection.map { |item|
+                     ^^^^^^^^^^^^ Use `filter_map` instead.
+          }.compact
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        do_something(
+          collection.filter_map { |item|
+          }
+        )
+      RUBY
+    end
+
     it 'registers an offense when using multiline `map { ... }.compact` and assigning to return value' do
       expect_offense(<<~RUBY)
         ret = collection.map do |item|


### PR DESCRIPTION
Fixes #257.

This PR fixes an incorrect auto-correct for `Performance/MapCompact` when using multi-line `collection.map { ... }.compact` as a method argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
