### PR TITLE
Unmark `AutoCorrect: false` from `Performance/StringInclude`

### DIFF
--- a/changelog/change_unmark_autocorrect_false_from_performance_string_include.md
+++ b/changelog/change_unmark_autocorrect_false_from_performance_string_include.md
@@ -1,0 +1,1 @@
+* [#263](https://github.com/rubocop/rubocop-performance/pull/263): Unmark `AutoCorrect: false` from `Performance/StringInclude`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -309,9 +309,9 @@ Performance/StartWith:
 Performance/StringInclude:
   Description: 'Use `String#include?` instead of a regex match with literal-only pattern.'
   Enabled: 'pending'
-  AutoCorrect: false
   SafeAutoCorrect: false
   VersionAdded: '1.7'
+  VersionChanged: '1.12'
 
 Performance/StringReplacement:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -1848,7 +1848,7 @@ for receiver is multiline string.
 | Yes
 | Yes (Unsafe)
 | 1.7
-| -
+| 1.12
 |===
 
 This cop identifies unnecessary use of a regex where
@@ -1871,16 +1871,6 @@ This cop's offenses are not safe to auto-correct if a receiver is nil.
 # good
 'abc'.include?('ab')
 ----
-
-=== Configurable attributes
-
-|===
-| Name | Default value | Configurable values
-
-| AutoCorrect
-| `false`
-| Boolean
-|===
 
 == Performance/StringReplacement
 


### PR DESCRIPTION
This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.

Test code for the autocorrection exists. So it can be enabled by default. However, it is still unsafe because `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
