### PR TITLE
Fix error in Performance/Sum when method has no brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,3 +296,4 @@
 [@dvandersluis]: https://github.com/dvandersluis
 [@ghiculescu]: https://github.com/ghiculescu
 [@mfbmina]: https://github.com/mfbmina
+[@mvz]: https://github.com/mvz

--- a/changelog/fix_fix_error_in_performancesum_when_method.md
+++ b/changelog/fix_fix_error_in_performancesum_when_method.md
@@ -1,0 +1,1 @@
+* [#264](https://github.com/rubocop/rubocop-performance/pull/264): Fix error in Performance/Sum when method has no brackets. ([@mvz][])

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -156,7 +156,7 @@ module RuboCop
         end
 
         def sum_method_range(node)
-          range_between(node.loc.selector.begin_pos, node.loc.end.end_pos)
+          range_between(node.loc.selector.begin_pos, node.loc.expression.end_pos)
         end
 
         def sum_map_range(map, sum)

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when using `array.#{method} 0, :+`" do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} 0, :+
+              ^{method}^^^^^^ Use `sum` instead of `#{method}(0, :+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
+    end
+
     it "registers an offense and corrects when using `array.#{method}(0.0, :+)`" do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(0.0, :+)
@@ -88,6 +99,15 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
 
         expect_no_corrections
       end
+
+      it 'does not autocorrect `:+` without brackets when initial value is not provided' do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method} :+
+                ^{method}^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
+        RUBY
+
+        expect_no_corrections
+      end
     end
 
     context 'when `SafeAutoCorrect: false' do
@@ -108,6 +128,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
         expect_offense(<<~RUBY, method: method)
           array.#{method}(&:+)
                 ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`, unless calling `#{method}(&:+)` on an empty array.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum
+        RUBY
+      end
+
+      it 'autocorrects `:+` without brackets when initial value is not provided' do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method} :+
+                ^{method}^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
         RUBY
 
         expect_correction(<<~RUBY)


### PR DESCRIPTION
This fixes an issue where code like the following would cause an error in the Performance/Sum cop:

```
arr.inject :+
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
