### PR TITLE
[Fix #261] Fix a false negative for `Performance/RedundantBlockCall`

### DIFF
--- a/changelog/fix_false_negative_for_performance_redundant_block_call.md
+++ b/changelog/fix_false_negative_for_performance_redundant_block_call.md
@@ -1,0 +1,1 @@
+* [#261](https://github.com/rubocop/rubocop-performance/issues/261): Fix a false negative for `Performance/RedundantBlockCall` when using `block.call` in a class method'. ([@koic][])

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -55,6 +55,7 @@ module RuboCop
             end
           end
         end
+        alias on_defs on_def
 
         private
 

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall, :config do
     RUBY
   end
 
+  it 'registers and corrects an offense when using `block.call` in a class method' do
+    expect_offense(<<~RUBY)
+      def self.method(&block)
+        block.call
+        ^^^^^^^^^^ Use `yield` instead of `block.call`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      def self.method(&block)
+        yield
+      end
+    RUBY
+  end
+
   it 'registers and autocorrects an offense when `block.call` with arguments' do
     expect_offense(<<~RUBY)
       def method(&block)


### PR DESCRIPTION
Fixes #261.

This PR fixes a false negative for `Performance/RedundantBlockCall` when using `block.call` in a class method'.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
