### PR TITLE
Add #to_d support to BigDecimalWithNumericArgument

### DIFF
--- a/changelog/new_add_to_d_to_BigDecimalWithNumericArgument.md
+++ b/changelog/new_add_to_d_to_BigDecimalWithNumericArgument.md
@@ -1,0 +1,1 @@
+* [#269](https://github.com/rubocop/rubocop-performance/pull/269): Add `#to_d` support to `BigDecimalWithNumericArgument`. ([@leoarnold][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -17,7 +17,7 @@ Performance/ArraySemiInfiniteRangeSlice:
   VersionAdded: '1.9'
 
 Performance/BigDecimalWithNumericArgument:
-  Description: 'Convert numeric argument to string before passing to BigDecimal.'
+  Description: 'Convert numeric literal to string and pass it to `BigDecimal`.'
   Enabled: 'pending'
   VersionAdded: '1.7'
 

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -99,11 +99,15 @@ than from Numeric for BigDecimal.
 ----
 # bad
 BigDecimal(1, 2)
+4.to_d(6)
 BigDecimal(1.2, 3, exception: true)
+4.5.to_d(6, exception: true)
 
 # good
 BigDecimal('1', 2)
+BigDecimal('4', 6)
 BigDecimal('1.2', 3, exception: true)
+BigDecimal('4.5', 6, exception: true)
 ----
 
 == Performance/BindCall

--- a/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
+++ b/lib/rubocop/cop/performance/big_decimal_with_numeric_argument.rb
@@ -10,35 +10,46 @@ module RuboCop
       # @example
       #   # bad
       #   BigDecimal(1, 2)
+      #   4.to_d(6)
       #   BigDecimal(1.2, 3, exception: true)
+      #   4.5.to_d(6, exception: true)
       #
       #   # good
       #   BigDecimal('1', 2)
+      #   BigDecimal('4', 6)
       #   BigDecimal('1.2', 3, exception: true)
+      #   BigDecimal('4.5', 6, exception: true)
       #
       class BigDecimalWithNumericArgument < Base
         extend AutoCorrector
 
-        MSG = 'Convert numeric argument to string before passing to `BigDecimal`.'
-        RESTRICT_ON_SEND = %i[BigDecimal].freeze
+        MSG = 'Convert numeric literal to string and pass it to `BigDecimal`.'
+        RESTRICT_ON_SEND = %i[BigDecimal to_d].freeze
 
         def_node_matcher :big_decimal_with_numeric_argument?, <<~PATTERN
           (send nil? :BigDecimal $numeric_type? ...)
         PATTERN
 
+        def_node_matcher :to_d?, <<~PATTERN
+          (send [!nil? $numeric_type?] :to_d ...)
+        PATTERN
+
         def on_send(node)
-          return unless (numeric = big_decimal_with_numeric_argument?(node))
-          return if numeric.float_type? && specifies_precision?(node)
+          if (numeric = big_decimal_with_numeric_argument?(node))
+            add_offense(numeric.source_range) do |corrector|
+              corrector.wrap(numeric, "'", "'")
+            end
+          elsif (numeric_to_d = to_d?(node))
+            add_offense(numeric_to_d.source_range) do |corrector|
+              big_decimal_args = node
+                                 .arguments
+                                 .map(&:source)
+                                 .unshift("'#{numeric_to_d.source}'")
+                                 .join(', ')
 
-          add_offense(numeric.source_range) do |corrector|
-            corrector.wrap(numeric, "'", "'")
+              corrector.replace(node, "BigDecimal(#{big_decimal_args})")
+            end
           end
-        end
-
-        private
-
-        def specifies_precision?(node)
-          node.arguments.size > 1 && !node.arguments[1].hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
+++ b/spec/rubocop/cop/performance/big_decimal_with_numeric_argument_spec.rb
@@ -4,7 +4,18 @@ RSpec.describe RuboCop::Cop::Performance::BigDecimalWithNumericArgument, :config
   it 'registers an offense and corrects when using `BigDecimal` with integer' do
     expect_offense(<<~RUBY)
       BigDecimal(1)
-                 ^ Convert numeric argument to string before passing to `BigDecimal`.
+                 ^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('1')
+    RUBY
+  end
+
+  it 'registers an offense and corrects when using `Integer#to_d`' do
+    expect_offense(<<~RUBY)
+      1.to_d
+      ^ Convert numeric literal to string and pass it to `BigDecimal`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -15,7 +26,7 @@ RSpec.describe RuboCop::Cop::Performance::BigDecimalWithNumericArgument, :config
   it 'registers an offense and corrects when using `BigDecimal` with float' do
     expect_offense(<<~RUBY)
       BigDecimal(1.5, exception: true)
-                 ^^^ Convert numeric argument to string before passing to `BigDecimal`.
+                 ^^^ Convert numeric literal to string and pass it to `BigDecimal`.
     RUBY
 
     expect_correction(<<~RUBY)
@@ -23,28 +34,96 @@ RSpec.describe RuboCop::Cop::Performance::BigDecimalWithNumericArgument, :config
     RUBY
   end
 
-  it 'does not register an offense when using `BigDecimal` with float and precision' do
-    expect_no_offenses(<<~RUBY)
-      BigDecimal(3.14, 1)
+  it 'registers an offense and corrects when using `Float#to_d`' do
+    expect_offense(<<~RUBY)
+      1.5.to_d(exception: true)
+      ^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('1.5', exception: true)
     RUBY
   end
 
-  it 'does not register an offense when using `BigDecimal` with float and non-literal precision' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense when using `BigDecimal` with float and precision' do
+    expect_offense(<<~RUBY)
+      BigDecimal(3.14, 1)
+                 ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('3.14', 1)
+    RUBY
+  end
+
+  it 'registers an offense when using `Float#to_d` with precision' do
+    expect_offense(<<~RUBY)
+      3.14.to_d(1)
+      ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('3.14', 1)
+    RUBY
+  end
+
+  it 'registers an offense when using `BigDecimal` with float and non-literal precision' do
+    expect_offense(<<~RUBY)
       precision = 1
       BigDecimal(3.14, precision)
+                 ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      precision = 1
+      BigDecimal('3.14', precision)
     RUBY
   end
 
-  it 'does not register an offense when using `BigDecimal` with float, precision, and a keyword argument' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense when using `Float#to_d` with non-literal precision' do
+    expect_offense(<<~RUBY)
+      precision = 1
+      3.14.to_d(precision)
+      ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      precision = 1
+      BigDecimal('3.14', precision)
+    RUBY
+  end
+
+  it 'registers an offense when using `BigDecimal` with float, precision, and a keyword argument' do
+    expect_offense(<<~RUBY)
       BigDecimal(3.14, 1, exception: true)
+                 ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('3.14', 1, exception: true)
+    RUBY
+  end
+
+  it 'registers an offense when using `Float#to_d` with precision and a keyword argument' do
+    expect_offense(<<~RUBY)
+      3.14.to_d(1, exception: true)
+      ^^^^ Convert numeric literal to string and pass it to `BigDecimal`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      BigDecimal('3.14', 1, exception: true)
     RUBY
   end
 
   it 'does not register an offense when using `BigDecimal` with string' do
     expect_no_offenses(<<~RUBY)
       BigDecimal('1')
+    RUBY
+  end
+
+  it 'does not register an offense when using `String#to_d`' do
+    expect_no_offenses(<<~RUBY)
+      '1'.to_d
     RUBY
   end
 end


### PR DESCRIPTION
The [`bigdecimal/util`](https://github.com/ruby/bigdecimal/blob/v3.0.2/lib/bigdecimal/util.rb) library adds `#to_d` to several numeric types, where

```ruby
numeric.to_d(*args)
```

is equivalent to

```ruby
BigDecimal(numeric, *args)
```

and the performance improvement of `BigDecimalWithNumericArgument`
therefore equally applies here.

Also, the exception of `Float` with specified precision does not seem
to make sense and is therefore dropped:

```
Warming up --------------------------------------
   BigDecimal("1.2")   266.340k i/100ms
BigDecimal("1.2", 9)   261.542k i/100ms
  BigDecimal(1.2, 9)    44.366k i/100ms
            1.2.to_d    42.809k i/100ms
         1.2.to_d(9)    43.915k i/100ms
Calculating -------------------------------------
   BigDecimal("1.2")      2.634M (± 1.8%) i/s -     13.317M in   5.056712s
BigDecimal("1.2", 9)      2.510M (± 5.4%) i/s -     12.554M in   5.016970s
  BigDecimal(1.2, 9)    330.664k (±32.5%) i/s -      1.464M in   5.055963s
            1.2.to_d    183.891k (± 7.3%) i/s -    941.798k in   5.148850s
         1.2.to_d(9)    189.455k (± 9.4%) i/s -    966.130k in   5.149545s
```

Generated with:

```ruby
require 'bigdecimal'
require 'bigdecimal/util'
require 'benchmark/ips'

numeric = 1.2
string = numeric.to_s
prec = rand(7..11)

Benchmark.ips do |ips|
  ips.report("BigDecimal(\"#{string}\")") { BigDecimal(string) }
  ips.report("BigDecimal(\"#{string}\", #{prec})") { BigDecimal(string, prec) }
  ips.report("BigDecimal(#{numeric}, #{prec})") { BigDecimal(numeric, prec) }
  ips.report("#{numeric}.to_d") { numeric.to_d  }
  ips.report("#{numeric}.to_d(#{prec})") { numeric.to_d(prec) }
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
