### PR TITLE
Mark `Performance/Sum` auto-correction as unsafe and extend documentation

### DIFF
--- a/changelog/change_mark_performancesum_autocorrection_as.md
+++ b/changelog/change_mark_performancesum_autocorrection_as.md
@@ -1,0 +1,1 @@
+* [#270](https://github.com/rubocop/rubocop-performance/pull/270): Mark `Performance/Sum` auto-correction as unsafe and extend documentation. ([@leoarnold][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -330,9 +330,11 @@ Performance/StringReplacement:
 
 Performance/Sum:
   Description: 'Use `sum` instead of a custom array summation.'
+  SafeAutoCorrect: false
   Reference: 'https://blog.bigbinary.com/2016/11/02/ruby-2-4-introduces-enumerable-sum.html'
   Enabled: 'pending'
   VersionAdded: '1.8'
+  VersionChanged: '1.13'
   OnlySumOrWithInitialValue: false
 
 Performance/TimesMap:

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -2013,37 +2013,49 @@ This cop identifies places where `gsub` can be replaced by
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 1.8
-| -
+| 1.13
 |===
 
 This cop identifies places where custom code finding the sum of elements
 in some Enumerable object can be replaced by `Enumerable#sum` method.
 
-This cop can change auto-correction scope depending on the value of
-`SafeAutoCorrect`.
-Its auto-correction is marked as safe by default (`SafeAutoCorrect: true`)
-to prevent `TypeError` in auto-correced code when initial value is not
-specified as shown below:
+=== Safety
+
+Auto-corrections are unproblematic wherever an initial value is provided explicitly:
 
 [source,ruby]
 ----
-['a', 'b'].sum # => (String can't be coerced into Integer)
+[1, 2, 3].reduce(4, :+) # => 10
+[1, 2, 3].sum(4) # => 10
+
+[].reduce(4, :+) # => 4
+[].sum(4) # => 4
 ----
 
-Therefore if initial value is not specified, unsafe auto-corrected will not occur.
+This also holds true for non-numeric types which implement a `:+` method:
 
-If you always want to enable auto-correction, you can set `SafeAutoCorrect: false`.
-
-[source,yaml]
+[source,ruby]
 ----
-Performance/Sum:
-  SafeAutoCorrect: false
+['l', 'o'].reduce('Hel', :+) # => "Hello"
+['l', 'o'].sum('Hel') # => "Hello"
 ----
 
-Please note that the auto-correction command line option will be changed from
-`rubocop -a` to `rubocop -A`, which includes unsafe auto-correction.
+When no initial value is provided though, `Enumerable#reduce` will pick the first enumerated value
+as initial value and successively add all following values to it, whereas
+`Enumerable#sum` will set an initial value of `0` (`Integer`) which can lead to a `TypeError`:
+
+[source,ruby]
+----
+[].reduce(:+) # => nil
+[1, 2, 3].reduce(:+) # => 6
+['H', 'e', 'l', 'l', 'o'].reduce(:+) # => "Hello"
+
+[].sum # => 0
+[1, 2, 3].sum # => 6
+['H', 'e', 'l', 'l', 'o'].sum # => in `+': String can't be coerced into Integer (TypeError)
+----
 
 === Examples
 
@@ -2052,9 +2064,9 @@ Please note that the auto-correction command line option will be changed from
 [source,ruby]
 ----
 # bad
-[1, 2, 3].inject(:+)                        # These bad cases with no initial value are unsafe and
-[1, 2, 3].inject(&:+)                       # will not be auto-correced by default. If you want to
-[1, 2, 3].reduce { |acc, elem| acc + elem } # auto-corrected, you can set `SafeAutoCorrect: false`.
+[1, 2, 3].inject(:+)                        # Auto-corrections for cases without initial value are unsafe
+[1, 2, 3].inject(&:+)                       # and will only be performed when using the `-A` option.
+[1, 2, 3].reduce { |acc, elem| acc + elem } # They can be prohibited completely using `SafeAutoCorrect: true`.
 [1, 2, 3].reduce(10, :+)
 [1, 2, 3].map { |elem| elem ** 2 }.sum
 [1, 2, 3].collect(&:count).sum(10)

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -232,43 +232,6 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       end
     end
 
-    context 'when `SafeAutoCorrect: false' do
-      let(:cop_config) { { 'SafeAutoCorrect' => false } }
-
-      it 'autocorrects `:+` when initial value is not provided' do
-        expect_offense(<<~RUBY, method: method)
-          array.#{method}(:+)
-                ^{method}^^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array.sum
-        RUBY
-      end
-
-      it 'autocorrects `&:+` when initial value is not provided' do
-        expect_offense(<<~RUBY, method: method)
-          array.#{method}(&:+)
-                ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`, unless calling `#{method}(&:+)` on an empty array.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array.sum
-        RUBY
-      end
-
-      it 'autocorrects `:+` without brackets when initial value is not provided' do
-        expect_offense(<<~RUBY, method: method)
-          array.#{method} :+
-                ^{method}^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          array.sum
-        RUBY
-      end
-    end
-
     it "registers an offense and corrects when using `array.#{method}(0, &:+)`" do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(0, &:+)
@@ -280,23 +243,48 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
-    it 'does not autocorrect `&:+` when initial value is not provided' do
+    it 'autocorrects `&:+` when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(&:+)
               ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`, unless calling `#{method}(&:+)` on an empty array.
       RUBY
 
-      expect_no_corrections
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
     end
 
-    # ideally it would autocorrect to `[1, 2, 3].sum`
-    it 'registers an offense but does not autocorrect on array literals' do
+    it 'autocorrects `:+` when initial value is not provided' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method}(:+)
+              ^{method}^^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
+    end
+
+    it 'autocorrects `:+` without brackets when initial value is not provided' do
+      expect_offense(<<~RUBY, method: method)
+        array.#{method} :+
+              ^{method}^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.sum
+      RUBY
+    end
+
+    it 'autocorrects `:+` on array literals when initial value is not provided' do
       expect_offense(<<~RUBY, method: method)
         [1, 2, 3].#{method}(:+)
                   ^{method}^^^^ Use `sum` instead of `#{method}(:+)`.
       RUBY
 
-      expect_no_corrections
+      expect_correction(<<~RUBY)
+        [1, 2, 3].sum
+      RUBY
     end
 
     it 'does not register an offense when the array is empty' do


### PR DESCRIPTION
The documentaion of `Performance/Sum` talked about setting
`SafeAutoCorrect: true` for the cop, but Rubocop complained:

```
Warning: Performance/Sum does not support SafeAutoCorrect parameter.

Supported parameters are:

  - Enabled

```

so we add the `SafeAutoCorrect` option to the cop's defaults
and thereby mark it as (partially) unsafe.

This is NOT a change in behavior: The cop will still perform all
safe auto-corrections when using `-a`, and also (by default)
perform all unsafe auto-corrections when using `-A`.

Furthermore we extend the documentation in order to make it even more
clear in _which_ cases auto-correction is unsafe, and _why_.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
