### PR TITLE
[Fix #204] Add `Performance/Sum` option to ignore potential false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,3 +312,4 @@
 [@ghiculescu]: https://github.com/ghiculescu
 [@mfbmina]: https://github.com/mfbmina
 [@mvz]: https://github.com/mvz
+[@leoarnold]: https://github.com/leoarnold

--- a/changelog/new_add_performancesum_option_to_ignore.md
+++ b/changelog/new_add_performancesum_option_to_ignore.md
@@ -1,0 +1,1 @@
+* [#204](https://github.com/rubocop/rubocop-performance/issues/204): Add `Performance/Sum` option to ignore potential false positives. ([@leoarnold][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -333,6 +333,7 @@ Performance/Sum:
   Reference: 'https://blog.bigbinary.com/2016/11/02/ruby-2-4-introduces-enumerable-sum.html'
   Enabled: 'pending'
   VersionAdded: '1.8'
+  OnlySumOrWithInitialValue: false
 
 Performance/TimesMap:
   Description: 'Checks for .times.map calls.'

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -2047,6 +2047,8 @@ Please note that the auto-correction command line option will be changed from
 
 === Examples
 
+==== OnlySumOrWithInitialValue: false (default)
+
 [source,ruby]
 ----
 # bad
@@ -2063,6 +2065,31 @@ Please note that the auto-correction command line option will be changed from
 [1, 2, 3].sum { |elem| elem ** 2 }
 [1, 2, 3].sum(10, &:count)
 ----
+
+==== OnlySumOrWithInitialValue: true
+
+[source,ruby]
+----
+# bad
+[1, 2, 3].reduce(10, :+)
+[1, 2, 3].map { |elem| elem ** 2 }.sum
+[1, 2, 3].collect(&:count).sum(10)
+
+# good
+[1, 2, 3].sum(10)
+[1, 2, 3].sum { |elem| elem ** 2 }
+[1, 2, 3].sum(10, &:count)
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| OnlySumOrWithInitialValue
+| `false`
+| Boolean
+|===
 
 === References
 

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -30,7 +30,7 @@ module RuboCop
       # Please note that the auto-correction command line option will be changed from
       # `rubocop -a` to `rubocop -A`, which includes unsafe auto-correction.
       #
-      # @example
+      # @example OnlySumOrWithInitialValue: false (default)
       #   # bad
       #   [1, 2, 3].inject(:+)                        # These bad cases with no initial value are unsafe and
       #   [1, 2, 3].inject(&:+)                       # will not be auto-correced by default. If you want to
@@ -41,6 +41,17 @@ module RuboCop
       #
       #   # good
       #   [1, 2, 3].sum
+      #   [1, 2, 3].sum(10)
+      #   [1, 2, 3].sum { |elem| elem ** 2 }
+      #   [1, 2, 3].sum(10, &:count)
+      #
+      # @example OnlySumOrWithInitialValue: true
+      #   # bad
+      #   [1, 2, 3].reduce(10, :+)
+      #   [1, 2, 3].map { |elem| elem ** 2 }.sum
+      #   [1, 2, 3].collect(&:count).sum(10)
+      #
+      #   # good
       #   [1, 2, 3].sum(10)
       #   [1, 2, 3].sum { |elem| elem ** 2 }
       #   [1, 2, 3].sum(10, &:count)
@@ -103,6 +114,8 @@ module RuboCop
 
         def handle_sum_candidate(node)
           sum_candidate?(node) do |method, init, operation|
+            next if cop_config['OnlySumOrWithInitialValue'] && init.empty?
+
             range = sum_method_range(node)
             message = build_method_message(node, method, init, operation)
 

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -79,6 +79,128 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
+    context 'when `OnlySumOrWithInitialValue: true`' do
+      let(:cop_config) { { 'OnlySumOrWithInitialValue' => true } }
+
+      it "registers an offense and corrects when using `array.#{method}(10, :+)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(10, :+)
+                ^{method}^^^^^^^^ Use `sum(10)` instead of `#{method}(10, :+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(10)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(10) { |acc, elem| acc + elem }`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(10) { |acc, elem| acc + elem }
+                ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum(10)` instead of `#{method}(10) { |acc, elem| acc + elem }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(10)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(10) { |acc, elem| elem + acc }`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(10) { |acc, elem| elem + acc }
+                ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum(10)` instead of `#{method}(10) { |acc, elem| elem + acc }`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(10)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(0, :+)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(0, :+)
+                ^{method}^^^^^^^ Use `sum` instead of `#{method}(0, :+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method} 0, :+`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method} 0, :+
+                ^{method}^^^^^^ Use `sum` instead of `#{method}(0, :+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(0.0, :+)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(0.0, :+)
+                ^{method}^^^^^^^^^ Use `sum(0.0)` instead of `#{method}(0.0, :+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(0.0)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(init, :+)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(init, :+)
+                ^{method}^^^^^^^^^^ Use `sum(init)` instead of `#{method}(init, :+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(init)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(0, &:+)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.#{method}(0, &:+)
+                ^{method}^^^^^^^^ Use `sum` instead of `#{method}(0, &:+)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum
+        RUBY
+      end
+
+      it 'does not register an offense on `&:+` when initial value is not provided' do
+        expect_no_offenses(<<~RUBY)
+          array.#{method}(&:+)
+        RUBY
+      end
+
+      it 'does not register an offense on array literals' do
+        expect_no_offenses(<<~RUBY)
+          [1, 2, 3].#{method}(:+)
+        RUBY
+      end
+
+      it 'does not register an offense when the array is empty' do
+        expect_no_offenses(<<~RUBY)
+          [].#{method}(:+)
+        RUBY
+      end
+
+      it 'does not register an offense when block does not implement summation' do
+        expect_no_offenses(<<~RUBY)
+          array.#{method} { |acc, elem| elem * 2 }
+        RUBY
+      end
+
+      it 'does not register an offense when using `sum`' do
+        expect_no_offenses(<<~RUBY)
+          array.sum
+        RUBY
+      end
+    end
+
     context 'when `SafeAutoCorrect: true' do
       let(:cop_config) { { 'SafeAutoCorrect' => true } }
 
@@ -262,6 +384,77 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       expect_no_offenses(<<~RUBY)
         array.#{method}(&:count).sum(&:count)
       RUBY
+    end
+
+    context 'when `SafeAutoCorrect: true' do
+      let(:cop_config) { { 'SafeAutoCorrect' => true } }
+
+      it "registers an offense and corrects when using `array.#{method} { |elem| elem ** 2 }.sum`" do
+        expect_offense(<<~RUBY, method: method)
+          array.%{method} { |elem| elem ** 2 }.sum
+                ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }.sum`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum { |elem| elem ** 2 }
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(&:count).sum`" do
+        expect_offense(<<~RUBY, method: method)
+          array.%{method}(&:count).sum
+                ^{method}^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }.sum`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(&:count)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `#{method}(&:count).sum`" do
+        expect_offense(<<~RUBY, method: method)
+          %{method}(&:count).sum
+          ^{method}^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }.sum`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          sum(&:count)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method}(&:count).sum(10)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.%{method}(&:count).sum(10)
+                ^{method}^^^^^^^^^^^^^^^^^ Use `sum(10) { ... }` instead of `%{method} { ... }.sum(10)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(10, &:count)
+        RUBY
+      end
+
+      it "registers an offense and corrects when using `array.#{method} { elem ** 2 }.sum(10)`" do
+        expect_offense(<<~RUBY, method: method)
+          array.%{method} { |elem| elem ** 2 }.sum(10)
+                ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum(10) { ... }` instead of `%{method} { ... }.sum(10)`.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          array.sum(10) { |elem| elem ** 2 }
+        RUBY
+      end
+
+      it "does not register an offense when using `array.#{method}(&:count).sum { |elem| elem ** 2 }`" do
+        expect_no_offenses(<<~RUBY)
+          array.#{method}(&:count).sum { |elem| elem ** 2 }
+        RUBY
+      end
+
+      it "does not register an offense when using `array.#{method}(&:count).sum(&:count)`" do
+        expect_no_offenses(<<~RUBY)
+          array.#{method}(&:count).sum(&:count)
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Some codebases may contain non-numeric classes which implement a `:+` method.
If `a`, `b` and `c` are objects of such a class, then certain corrections
do not apply:

```ruby
[a, b].reduce(c, :+) # is equivalent to
[a, b].sum(c)

[a, b].map(&:to_i).sum # is equivalent to
[a, b].sum(&:to_i)

[a, b].reduce(:+) # works
[a, b].sum # raises TypeError
```

For users who wish to only register offenses where auto-correction
is unproblematic, we add the option `OnlySumOrWithInitialValue`
to the `Performance/Sum` cop.

The option is disabled by default, so standard behavior is preserved,
and can be activated by setting `OnlySumOrWithInitialValue: true`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
