### PR TITLE
Add Sequel compatibility mode to `Performance/Detect`

### DIFF
--- a/changelog/change_add_sequel_compatibility_mode_to.md
+++ b/changelog/change_add_sequel_compatibility_mode_to.md
@@ -1,0 +1,1 @@
+* [#272](https://github.com/rubocop/rubocop-performance/pull/272): Add Sequel compatibility mode to `Performance/Detect`. ([@leoarnold][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -127,7 +127,8 @@ Performance/Detect:
   SafeAutoCorrect: false
   Enabled: true
   VersionAdded: '0.30'
-  VersionChanged: '1.8'
+  VersionChanged: '1.13'
+  SequelCompatibilityMode: false
 
 Performance/DoubleStartEndWith:
   Description: >-

--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -753,7 +753,7 @@ str.sub!(/suffix$/, '')
 | Yes
 | Yes (Unsafe)
 | 0.30
-| 1.8
+| 1.13
 |===
 
 This cop is used to identify usages of `first`, `last`, `[0]` or `[-1]`
@@ -789,6 +789,24 @@ meaning. Correcting `ActiveRecord` methods with this cop should be considered un
 [].detect { |item| true }
 [].reverse.detect { |item| true }
 ----
+
+==== SequelCompatibilityMode: true
+
+[source,ruby]
+----
+# good
+connection[:my_table].select { sum(nominal_value).as(total_nominal_value) }.first
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| SequelCompatibilityMode
+| `false`
+| Boolean
+|===
 
 === References
 


### PR DESCRIPTION
When using the `sequel` gem, a typical SQL query may look like

```ruby
connection[:my_table].select { sum(nominal_value).as(total_nominal_value) }.first
```

where the `:select` method represents the SQL `SELECT` statement
and not `Enumerable#select`.

To avoid registering offenses for these cases, we add the option
`SequelCompatibilityMode` (off by default) to the `Performance/Detect`
cop. When activated, the construction

```ruby
x.select { ... }.first
```

does not constitute an offense if and only if the block passed
has zero arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
