### PR TITLE
Change from `AutoCorrect: false` to `SafeAutoCorrect: false` for  `Performance/CaseWhenSplat`

### DIFF
--- a/changelog/change_unmark_autocorrect_false_from_performance_case_when_splat.md
+++ b/changelog/change_unmark_autocorrect_false_from_performance_case_when_splat.md
@@ -1,0 +1,1 @@
+* [#274](https://github.com/rubocop/rubocop-performance/pull/274): Unmark `AutoCorrect: false` from `Performance/CaseWhenSplat`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -43,10 +43,9 @@ Performance/CaseWhenSplat:
                  Reordering `when` conditions with a splat to the end
                  of the `when` branches can improve performance.
   Enabled: false
-  AutoCorrect: false
   SafeAutoCorrect: false
   VersionAdded: '0.34'
-  VersionChanged: '0.59'
+  VersionChanged: '<<next>>'
 
 Performance/Casecmp:
   Description: >-


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/6177.

This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
