### PR TITLE
Change from `AutoCorrect: false` to `SafeAutoCorrect: false` for  `Performance/TimesMap`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -339,11 +339,11 @@ Performance/Sum:
 
 Performance/TimesMap:
   Description: 'Checks for .times.map calls.'
-  AutoCorrect: false
   Enabled: true
+  # See https://github.com/rubocop/rubocop/issues/4658
+  SafeAutoCorrect: false
   VersionAdded: '0.36'
-  VersionChanged: '0.50'
-  SafeAutoCorrect: false # see https://github.com/rubocop/rubocop/issues/4658
+  VersionChanged: '<<next>>'
 
 Performance/UnfreezeString:
   Description: 'Use unary plus to get an unfrozen string literal.'


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/pull/6177.

This `AutoCorrect: false` looks like it was set when there was no way to safe autocorrect by `SafeAutocorrect: false`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
