### PR TITLE
Fix an incorrect autocorrect for `Performance/MapCompact`

### DIFF
--- a/changelog/fix_incorrect_autocorrect_for_performance_map_compact.md
+++ b/changelog/fix_incorrect_autocorrect_for_performance_map_compact.md
@@ -1,0 +1,1 @@
+* [#277](https://github.com/rubocop/rubocop-performance/pull/277): Fix an incorrect autocorrect for `Performance/MapCompact` when using `map.compact.first` and there is a line break after `map.compact` and receiver. ([@koic][])

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -102,6 +102,22 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using `map.compact.first` and there is a line break after `map.compact` ' \
+       'and receiver' do
+      expect_offense(<<~RUBY)
+        collection
+          .map { |item| item.do_something }.compact
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection
+          .filter_map { |item| item.do_something }
+          .first
+      RUBY
+    end
+
     it 'registers an offense when using `map { ... }.compact`' do
       expect_offense(<<~RUBY)
         collection.map { |item|


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `Performance/MapCompact` when using `map.compact.first` and there is a line break after `map.compact` and receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
