### PR TITLE
[Fix #278] Fix a false positive for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_false_positive_for_performance_string_identifier_argument.md
+++ b/changelog/fix_false_positive_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#278](https://github.com/rubocop/rubocop-performance/issues/278): Fix a false positive for `Performance/StringIdentifierArgument` when using `attr`. ([@koic][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -27,8 +27,11 @@ module RuboCop
 
         MSG = 'Use `%<symbol_arg>s` instead of `%<string_arg>s`.'
 
+        # NOTE: `attr` method is not included in this list as it can cause false positives in Nokogiri API.
+        # And `attr` may not be used because `Style/Attr` registers an offense.
+        # https://github.com/rubocop/rubocop-performance/issues/278
         RESTRICT_ON_SEND = %i[
-          alias_method attr attr_accessor attr_reader attr_writer autoload autoload?
+          alias_method attr_accessor attr_reader attr_writer autoload autoload?
           class_variable_defined? const_defined? const_get const_set const_source_location
           define_method instance_method method_defined? private_class_method? private_method_defined?
           protected_method_defined? public_class_method public_instance_method public_method_defined?

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -50,4 +50,13 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
       send(':foo is :bar', foo, bar)
     RUBY
   end
+
+  # NOTE: `attr` method is not included in this list as it can cause false positives in Nokogiri API.
+  # And `attr` may not be used because `Style/Attr` registers an offense.
+  # https://github.com/rubocop/rubocop-performance/issues/278
+  it 'does not register an offense when using string argument for `attr` method' do
+    expect_no_offenses(<<~RUBY)
+      attr('foo')
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #278.

This PR fixes a false positive for `Performance/StringIdentifierArgument` when using `attr`. `attr` may not be used because `Style/Attr` registers an offense.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
