### PR TITLE
[Fix #281] Fix an error for `Performance/BlockGivenWithExplicitBlock`

### DIFF
--- a/changelog/fix_an_error_for_performance_block_given_with_explicit_block.md
+++ b/changelog/fix_an_error_for_performance_block_given_with_explicit_block.md
@@ -1,0 +1,1 @@
+* [#281](https://github.com/rubocop/rubocop-performance/issues/281): Fix an error for `Performance/BlockGivenWithExplicitBlock` when using Ruby 3.1's anonymous block forwarding. ([@koic][])

--- a/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
+++ b/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
@@ -38,8 +38,9 @@ module RuboCop
 
           block_arg = def_node.arguments.find(&:blockarg_type?)
           return unless block_arg
+          return unless (block_arg_name = block_arg.loc.name)
 
-          block_arg_name = block_arg.loc.name.source.to_sym
+          block_arg_name = block_arg_name.source.to_sym
           return if reassigns_block_arg?(def_node, block_arg_name)
 
           add_offense(node) do |corrector|

--- a/spec/rubocop/cop/performance/block_given_with_explicit_block_spec.rb
+++ b/spec/rubocop/cop/performance/block_given_with_explicit_block_spec.rb
@@ -68,4 +68,15 @@ RSpec.describe RuboCop::Cop::Performance::BlockGivenWithExplicitBlock, :config d
       do_something if block_given?
     RUBY
   end
+
+  context 'when Ruby >= 3.1', :ruby31 do
+    it 'does not register an offense when using anonymous block argument' do
+      expect_no_offenses(<<~RUBY)
+        def method(x, &)
+          raise ArgumentError, "block required" unless block_given?
+          do_something(&)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #281.

This PR fixes an error for `Performance/BlockGivenWithExplicitBlock` when using Ruby 3.1's anonymous block forwarding.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
