### PR TITLE
Fix an error for `Performance/MapCompact` when using `map(&:do_something).compact.first` and there is a line break after `map.compact` and receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,3 +344,4 @@
 [@mfbmina]: https://github.com/mfbmina
 [@mvz]: https://github.com/mvz
 [@leoarnold]: https://github.com/leoarnold
+[@ydah]: https://github.com/ydah

--- a/changelog/fix_fix_error_for_performance_mapcorrect_when_line_break.md
+++ b/changelog/fix_fix_error_for_performance_mapcorrect_when_line_break.md
@@ -1,0 +1,1 @@
+* [#285](https://github.com/rubocop/rubocop-performance/pull/285): Fix an error for `Performance/MapCompact` when using `map(&:do_something).compact.first` and there is a line break after `map.compact` and receiver. ([@ydah][])

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -58,17 +58,17 @@ module RuboCop
 
           add_offense(range) do |corrector|
             corrector.replace(map_node.loc.selector, 'filter_map')
-            remove_compact_method(corrector, node, node.parent)
+            remove_compact_method(corrector, map_node, node, node.parent)
           end
         end
 
         private
 
-        def remove_compact_method(corrector, compact_node, chained_method)
+        def remove_compact_method(corrector, map_node, compact_node, chained_method)
           compact_method_range = compact_node.loc.selector
 
           if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) && chained_method.dot? &&
-             !map_method_and_compact_method_on_same_line?(compact_node) &&
+             !map_method_and_compact_method_on_same_line?(map_node, compact_node) &&
              !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
             compact_method_range = compact_method_with_final_newline_range(compact_method_range)
           else
@@ -78,11 +78,7 @@ module RuboCop
           corrector.remove(compact_method_range)
         end
 
-        def map_method_and_compact_method_on_same_line?(compact_node)
-          return false unless compact_node.children.first.respond_to?(:send_node)
-
-          map_node = compact_node.children.first.send_node
-
+        def map_method_and_compact_method_on_same_line?(map_node, compact_node)
           compact_node.loc.selector.line == map_node.loc.selector.line
         end
 

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -46,7 +46,81 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `map.compact.first` with single-line method calls' do
+    it 'registers an offense when using `map(&:do_something).compact.first` with single-line method calls' do
+      expect_offense(<<~RUBY)
+        collection.map(&:do_something).compact.first
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map(&:do_something).first
+      RUBY
+    end
+
+    it 'registers an offense when using `map(&:do_something).compact.first` with multi-line leading dot method calls' do
+      expect_offense(<<~RUBY)
+        collection
+          .map(&:do_something)
+           ^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .compact
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection
+          .filter_map(&:do_something)
+          .first
+      RUBY
+    end
+
+    it 'registers an offense when using `map(&:do_something).compact.first` with multi-line trailing' \
+       'dot method calls' do
+      expect_offense(<<~RUBY)
+        collection.
+          map(&:do_something).
+          ^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          compact.
+          first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.
+          filter_map(&:do_something).
+          first
+      RUBY
+    end
+
+    it 'registers an offense when using `map(&:do_something).compact.first` and there is a line break after' \
+       '`map.compact`' do
+      expect_offense(<<~RUBY)
+        collection.map(&:do_something).compact
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection.filter_map(&:do_something)
+          .first
+      RUBY
+    end
+
+    it 'registers an offense when using `map(&:do_something).compact.first` and there is a line break after' \
+       '`map.compact` and receiver' do
+      expect_offense(<<~RUBY)
+        collection
+          .map(&:do_something).compact
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+          .first
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection
+          .filter_map(&:do_something)
+          .first
+      RUBY
+    end
+
+    it 'registers an offense when using `map { ... }.compact.first` with single-line method calls' do
       expect_offense(<<~RUBY)
         collection.map { |item| item.do_something }.compact.first
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
@@ -57,7 +131,7 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `map.compact.first` with multi-line leading dot method calls' do
+    it 'registers an offense when using `map { ... }.compact.first` with multi-line leading dot method calls' do
       expect_offense(<<~RUBY)
         collection
           .map { |item| item.do_something }
@@ -73,7 +147,7 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `map.compact.first` with multi-line trailing dot method calls' do
+    it 'registers an offense when using `map { ... }.compact.first` with multi-line trailing dot method calls' do
       expect_offense(<<~RUBY)
         collection.
           map { |item| item.do_something }.
@@ -89,7 +163,7 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `map.compact.first` and there is a line break after `map.compact`' do
+    it 'registers an offense when using `map { ... }.compact.first` and there is a line break after `map.compact`' do
       expect_offense(<<~RUBY)
         collection.map { |item| item.do_something }.compact
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
@@ -102,7 +176,7 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `map.compact.first` and there is a line break after `map.compact` ' \
+    it 'registers an offense when using `map { ... }.compact.first` and there is a line break after `map.compact` ' \
        'and receiver' do
       expect_offense(<<~RUBY)
         collection


### PR DESCRIPTION
This fixes an issue where code like the following would cause an error in the `Performance/MapCompact` cop:

```ruby
collection
  .map(&:do_something).compact
  .first
```

The following error was outcome:
```
An error occurred while Performance/MapCompact cop was inspecting /home/ydah/sandbox/test.rb:1:0.
Parser::Source::TreeRewriter detected clobbering
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter.rb:427:in `trigger_policy'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter.rb:414:in `enforce_policy'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:233:in `call'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:233:in `swallow'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:97:in `with'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:119:in `place_in_hierarchy'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:106:in `do_combine'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter/action.rb:30:in `combine'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter.rb:400:in `combine'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter.rb:194:in `replace'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/parser-3.1.1.0/lib/parser/source/tree_rewriter.rb:218:in `remove'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.13.2/lib/rubocop/cop/performance/map_compact.rb:78:in `remove_compact_method'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.13.2/lib/rubocop/cop/performance/map_compact.rb:61:in `block in on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/base.rb:342:in `correct'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/base.rb:127:in `add_offense'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-performance-1.13.2/lib/rubocop/cop/performance/map_compact.rb:59:in `on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:136:in `public_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:136:in `block (2 levels) in trigger_restricted_cops'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:160:in `with_cop_error_handling'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:135:in `block in trigger_restricted_cops'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:134:in `each'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:134:in `trigger_restricted_cops'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:70:in `on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:158:in `block in on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:155:in `each'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:155:in `each_with_index'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:155:in `on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:71:in `on_send'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.16.0/lib/rubocop/ast/traversal.rb:20:in `walk'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/commissioner.rb:86:in `investigate'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/team.rb:155:in `investigate_partial'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cop/team.rb:83:in `investigate'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:309:in `inspect_file'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:253:in `block in do_inspection_loop'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:287:in `block in iterate_until_no_changes'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:280:in `loop'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:280:in `iterate_until_no_changes'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:249:in `do_inspection_loop'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:130:in `block in file_offenses'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:155:in `file_offense_cache'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:129:in `file_offenses'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:120:in `process_file'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:101:in `block in each_inspected_file'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:100:in `each'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:100:in `reduce'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:100:in `each_inspected_file'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:86:in `inspect_files'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/runner.rb:47:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/command/execute_runner.rb:26:in `block in execute_runner'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/command/execute_runner.rb:52:in `with_redirect'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/command/execute_runner.rb:25:in `execute_runner'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/command/execute_runner.rb:17:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/command.rb:11:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli/environment.rb:18:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli.rb:71:in `run_command'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli.rb:78:in `execute_runners'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/lib/rubocop/cli.rb:47:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/exe/rubocop:12:in `block in <top (required)>'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rubocop-1.25.1/exe/rubocop:12:in `<top (required)>'
/home/ydah/.rbenv/versions/2.7.2/bin/rubocop:23:in `load'
/home/ydah/.rbenv/versions/2.7.2/bin/rubocop:23:in `<top (required)>'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli/exec.rb:58:in `load'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli/exec.rb:58:in `kernel_load'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli/exec.rb:23:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli.rb:479:in `exec'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli.rb:31:in `dispatch'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/cli.rb:25:in `start'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/exe/bundle:49:in `block in <top (required)>'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
/home/ydah/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.33/exe/bundle:37:in `<top (required)>'
/home/ydah/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
/home/ydah/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
```

Versions:
- rubocop: 1.25.1 (using Parser 3.1.1.0, rubocop-ast 1.16.0, running on ruby 2.7.2 x86_64-darwin20)
- rubocop-performance: 1.13.2

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
