### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.5
-          image: cimg/ruby:2.5
-      - rake_default:
           name: Ruby 2.6
           image: cimg/ruby:2.6
       - rake_default:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/changelog/change_drop_ruby_2_5_support.md
+++ b/changelog/change_drop_ruby_2_5_support.md
@@ -1,0 +1,1 @@
+* [#287](https://github.com/rubocop/rubocop-performance/pull/287): **(Breaking)** Drop Ruby 2.5 support. ([@koic][])

--- a/lib/rubocop/cop/mixin/regexp_metacharacter.rb
+++ b/lib/rubocop/cop/mixin/regexp_metacharacter.rb
@@ -54,9 +54,9 @@ module RuboCop
 
       def drop_start_metacharacter(regexp_string)
         if regexp_string.start_with?('\\A')
-          regexp_string[2..-1] # drop `\A` anchor
+          regexp_string[2..] # drop `\A` anchor
         else
-          regexp_string[1..-1] # drop `^` anchor
+          regexp_string[1..] # drop `^` anchor
         end
       end
 

--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -168,7 +168,7 @@ module RuboCop
 
         def needs_reorder?(when_node)
           following_branches =
-            when_node.parent.when_branches[(when_node.branch_index + 1)..-1]
+            when_node.parent.when_branches[(when_node.branch_index + 1)..]
 
           following_branches.any? do |when_branch|
             when_branch.conditions.any? do |condition|

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10577.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
