### PR TITLE
Recover Ruby 2.4 code analysis using `TargetRubyVersion: 2.4`

### DIFF
--- a/changelog/fix_recover_ruby_24_analysis.md
+++ b/changelog/fix_recover_ruby_24_analysis.md
@@ -1,0 +1,1 @@
+* [#288](https://github.com/rubocop/rubocop-performance/pull/288): Recover Ruby 2.4 code analysis using `TargetRubyVersion: 2.4`. ([@koic][])

--- a/lib/rubocop/cop/performance/delete_prefix.rb
+++ b/lib/rubocop/cop/performance/delete_prefix.rb
@@ -49,6 +49,9 @@ module RuboCop
       class DeletePrefix < Base
         include RegexpMetacharacter
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.5
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         RESTRICT_ON_SEND = %i[gsub gsub! sub sub!].freeze

--- a/lib/rubocop/cop/performance/delete_suffix.rb
+++ b/lib/rubocop/cop/performance/delete_suffix.rb
@@ -49,6 +49,9 @@ module RuboCop
       class DeleteSuffix < Base
         include RegexpMetacharacter
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.5
 
         MSG = 'Use `%<prefer>s` instead of `%<current>s`.'
         RESTRICT_ON_SEND = %i[gsub gsub! sub sub!].freeze

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -25,6 +25,9 @@ module RuboCop
       #
       class RedundantEqualityComparisonBlock < Base
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.5
 
         MSG = 'Use `%<prefer>s` instead of block.'
 

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -4,87 +4,37 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'when using `\A` as starting pattern' do
-    it "registers an offense and corrects when `gsub(/\Aprefix/, '')`" do
-      expect_offense(<<~RUBY)
+  context 'when TargetRubyVersion <= 2.4', :ruby24 do
+    it "does not register an offense when using `gsub(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.gsub(/\\Aprefix/, '')
-            ^^^^ Use `delete_prefix` instead of `gsub`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_prefix('prefix')
       RUBY
     end
 
-    it "registers an offense and corrects when `gsub!(/\Aprefix/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `gsub!(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.gsub!(/\\Aprefix/, '')
-            ^^^^^ Use `delete_prefix!` instead of `gsub!`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_prefix!('prefix')
       RUBY
     end
 
-    it "registers an offense and corrects when `sub(/\Aprefix/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `sub(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.sub(/\\Aprefix/, '')
-            ^^^ Use `delete_prefix` instead of `sub`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_prefix('prefix')
       RUBY
     end
 
-    it "registers an offense and corrects when `sub!(/\Aprefix/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `sub!(/\Aprefix/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.sub!(/\\Aprefix/, '')
-            ^^^^ Use `delete_prefix!` instead of `sub!`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_prefix!('prefix')
       RUBY
     end
   end
 
-  context 'when using `^` as starting pattern' do
-    context 'when `SafeMultiline: true`' do
-      let(:safe_multiline) { true }
-
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/^prefix/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/^prefix/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/^prefix/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/^prefix/, '')
-        RUBY
-      end
-    end
-
-    context 'when `SafeMultiline: false`' do
-      let(:safe_multiline) { false }
-
-      it 'registers an offense and corrects when using `gsub`' do
+  context 'when TargetRubyVersion >= 2.5', :ruby25 do
+    context 'when using `\A` as starting pattern' do
+      it "registers an offense and corrects when `gsub(/\Aprefix/, '')`" do
         expect_offense(<<~RUBY)
-          str.gsub(/^prefix/, '')
+          str.gsub(/\\Aprefix/, '')
               ^^^^ Use `delete_prefix` instead of `gsub`.
         RUBY
 
@@ -93,9 +43,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `gsub!`' do
+      it "registers an offense and corrects when `gsub!(/\Aprefix/, '')`" do
         expect_offense(<<~RUBY)
-          str.gsub!(/^prefix/, '')
+          str.gsub!(/\\Aprefix/, '')
               ^^^^^ Use `delete_prefix!` instead of `gsub!`.
         RUBY
 
@@ -104,9 +54,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `sub`' do
+      it "registers an offense and corrects when `sub(/\Aprefix/, '')`" do
         expect_offense(<<~RUBY)
-          str.sub(/^prefix/, '')
+          str.sub(/\\Aprefix/, '')
               ^^^ Use `delete_prefix` instead of `sub`.
         RUBY
 
@@ -115,9 +65,9 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `sub!`' do
+      it "registers an offense and corrects when `sub!(/\Aprefix/, '')`" do
         expect_offense(<<~RUBY)
-          str.sub!(/^prefix/, '')
+          str.sub!(/\\Aprefix/, '')
               ^^^^ Use `delete_prefix!` instead of `sub!`.
         RUBY
 
@@ -126,95 +76,173 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
         RUBY
       end
     end
-  end
 
-  context 'when using non-starting pattern' do
-    it 'does not register an offense when using `gsub`' do
+    context 'when using `^` as starting pattern' do
+      context 'when `SafeMultiline: true`' do
+        let(:safe_multiline) { true }
+
+        it 'does not register an offense and corrects when using `gsub`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `gsub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub!(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub(/^prefix/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub!(/^prefix/, '')
+          RUBY
+        end
+      end
+
+      context 'when `SafeMultiline: false`' do
+        let(:safe_multiline) { false }
+
+        it 'registers an offense and corrects when using `gsub`' do
+          expect_offense(<<~RUBY)
+            str.gsub(/^prefix/, '')
+                ^^^^ Use `delete_prefix` instead of `gsub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix('prefix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `gsub!`' do
+          expect_offense(<<~RUBY)
+            str.gsub!(/^prefix/, '')
+                ^^^^^ Use `delete_prefix!` instead of `gsub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix!('prefix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub`' do
+          expect_offense(<<~RUBY)
+            str.sub(/^prefix/, '')
+                ^^^ Use `delete_prefix` instead of `sub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix('prefix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub!`' do
+          expect_offense(<<~RUBY)
+            str.sub!(/^prefix/, '')
+                ^^^^ Use `delete_prefix!` instead of `sub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_prefix!('prefix')
+          RUBY
+        end
+      end
+    end
+
+    context 'when using non-starting pattern' do
+      it 'does not register an offense when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/pattern/, '')
+        RUBY
+      end
+    end
+
+    context 'with starting pattern `\A` and ending pattern `\z`' do
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/\\Aprefix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/\\Aprefix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Aprefix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Aprefix\\z/, '')
+        RUBY
+      end
+    end
+
+    context 'when using a non-blank string as replacement string' do
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/\\Aprefix/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/\\Aprefix/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Aprefix/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Aprefix/, 'foo')
+        RUBY
+      end
+    end
+
+    it 'does not register an offense when using `delete_prefix`' do
       expect_no_offenses(<<~RUBY)
-        str.gsub(/pattern/, '')
+        str.delete_prefix('prefix')
       RUBY
     end
 
-    it 'does not register an offense when using `gsub!`' do
+    it 'does not register an offense when using `delete_prefix!`' do
       expect_no_offenses(<<~RUBY)
-        str.gsub!(/pattern/, '')
+        str.delete_prefix!('prefix')
       RUBY
     end
-
-    it 'does not register an offense when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/pattern/, '')
-      RUBY
-    end
-
-    it 'does not register an offense when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/pattern/, '')
-      RUBY
-    end
-  end
-
-  context 'with starting pattern `\A` and ending pattern `\z`' do
-    it 'does not register an offense and corrects when using `gsub`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub(/\\Aprefix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `gsub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub!(/\\Aprefix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/\\Aprefix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/\\Aprefix\\z/, '')
-      RUBY
-    end
-  end
-
-  context 'when using a non-blank string as replacement string' do
-    it 'does not register an offense and corrects when using `gsub`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub(/\\Aprefix/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `gsub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub!(/\\Aprefix/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/\\Aprefix/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/\\Aprefix/, 'foo')
-      RUBY
-    end
-  end
-
-  it 'does not register an offense when using `delete_prefix`' do
-    expect_no_offenses(<<~RUBY)
-      str.delete_prefix('prefix')
-    RUBY
-  end
-
-  it 'does not register an offense when using `delete_prefix!`' do
-    expect_no_offenses(<<~RUBY)
-      str.delete_prefix!('prefix')
-    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -4,87 +4,37 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
   let(:cop_config) { { 'SafeMultiline' => safe_multiline } }
   let(:safe_multiline) { true }
 
-  context 'when using `\z` as ending pattern' do
-    it "registers an offense and corrects when `gsub(/suffix\z/, '')`" do
-      expect_offense(<<~RUBY)
+  context 'when TargetRubyVersion <= 2.4', :ruby24 do
+    it "does not register an offense when using `gsub(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.gsub(/suffix\\z/, '')
-            ^^^^ Use `delete_suffix` instead of `gsub`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_suffix('suffix')
       RUBY
     end
 
-    it "registers an offense and corrects when `gsub!(/suffix\z/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `gsub!(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.gsub!(/suffix\\z/, '')
-            ^^^^^ Use `delete_suffix!` instead of `gsub!`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_suffix!('suffix')
       RUBY
     end
 
-    it "registers an offense and corrects when `sub(/suffix\z/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `sub(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.sub(/suffix\\z/, '')
-            ^^^ Use `delete_suffix` instead of `sub`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_suffix('suffix')
       RUBY
     end
 
-    it "registers an offense and corrects when `sub!(/suffix\z/, '')`" do
-      expect_offense(<<~RUBY)
+    it "does not register an offense when using `sub!(/suffix\z/, '')`" do
+      expect_no_offenses(<<~RUBY)
         str.sub!(/suffix\\z/, '')
-            ^^^^ Use `delete_suffix!` instead of `sub!`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        str.delete_suffix!('suffix')
       RUBY
     end
   end
 
-  context 'when using `$` as ending pattern' do
-    context 'when `SafeMultiline: true`' do
-      let(:safe_multiline) { true }
-
-      it 'does not register an offense and corrects when using `gsub`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub(/suffix$/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `gsub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.gsub!(/suffix$/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub(/suffix$/, '')
-        RUBY
-      end
-
-      it 'does not register an offense and corrects when using `sub!`' do
-        expect_no_offenses(<<~RUBY)
-          str.sub!(/suffix$/, '')
-        RUBY
-      end
-    end
-
-    context 'when `SafeMultiline: false`' do
-      let(:safe_multiline) { false }
-
-      it 'registers an offense and corrects when using `gsub`' do
+  context 'when TargetRubyVersion >= 2.5', :ruby25 do
+    context 'when using `\z` as ending pattern' do
+      it "registers an offense and corrects when `gsub(/suffix\z/, '')`" do
         expect_offense(<<~RUBY)
-          str.gsub(/suffix$/, '')
+          str.gsub(/suffix\\z/, '')
               ^^^^ Use `delete_suffix` instead of `gsub`.
         RUBY
 
@@ -93,9 +43,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `gsub!`' do
+      it "registers an offense and corrects when `gsub!(/suffix\z/, '')`" do
         expect_offense(<<~RUBY)
-          str.gsub!(/suffix$/, '')
+          str.gsub!(/suffix\\z/, '')
               ^^^^^ Use `delete_suffix!` instead of `gsub!`.
         RUBY
 
@@ -104,9 +54,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `sub`' do
+      it "registers an offense and corrects when `sub(/suffix\z/, '')`" do
         expect_offense(<<~RUBY)
-          str.sub(/suffix$/, '')
+          str.sub(/suffix\\z/, '')
               ^^^ Use `delete_suffix` instead of `sub`.
         RUBY
 
@@ -115,9 +65,9 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
 
-      it 'registers an offense and corrects when using `sub!`' do
+      it "registers an offense and corrects when `sub!(/suffix\z/, '')`" do
         expect_offense(<<~RUBY)
-          str.sub!(/suffix$/, '')
+          str.sub!(/suffix\\z/, '')
               ^^^^ Use `delete_suffix!` instead of `sub!`.
         RUBY
 
@@ -126,95 +76,173 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
         RUBY
       end
     end
-  end
 
-  context 'when using non-ending pattern' do
-    it 'does not register an offense when using `gsub`' do
+    context 'when using `$` as ending pattern' do
+      context 'when `SafeMultiline: true`' do
+        let(:safe_multiline) { true }
+
+        it 'does not register an offense and corrects when using `gsub`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `gsub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.gsub!(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub(/suffix$/, '')
+          RUBY
+        end
+
+        it 'does not register an offense and corrects when using `sub!`' do
+          expect_no_offenses(<<~RUBY)
+            str.sub!(/suffix$/, '')
+          RUBY
+        end
+      end
+
+      context 'when `SafeMultiline: false`' do
+        let(:safe_multiline) { false }
+
+        it 'registers an offense and corrects when using `gsub`' do
+          expect_offense(<<~RUBY)
+            str.gsub(/suffix$/, '')
+                ^^^^ Use `delete_suffix` instead of `gsub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix('suffix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `gsub!`' do
+          expect_offense(<<~RUBY)
+            str.gsub!(/suffix$/, '')
+                ^^^^^ Use `delete_suffix!` instead of `gsub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix!('suffix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub`' do
+          expect_offense(<<~RUBY)
+            str.sub(/suffix$/, '')
+                ^^^ Use `delete_suffix` instead of `sub`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix('suffix')
+          RUBY
+        end
+
+        it 'registers an offense and corrects when using `sub!`' do
+          expect_offense(<<~RUBY)
+            str.sub!(/suffix$/, '')
+                ^^^^ Use `delete_suffix!` instead of `sub!`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            str.delete_suffix!('suffix')
+          RUBY
+        end
+      end
+    end
+
+    context 'when using non-ending pattern' do
+      it 'does not register an offense when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/pattern/, '')
+        RUBY
+      end
+
+      it 'does not register an offense when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/pattern/, '')
+        RUBY
+      end
+    end
+
+    context 'with starting pattern `\A` and ending pattern `\z`' do
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/\\Asuffix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/\\Asuffix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/\\Asuffix\\z/, '')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/\\Asuffix\\z/, '')
+        RUBY
+      end
+    end
+
+    context 'when using a non-blank string as replacement string' do
+      it 'does not register an offense and corrects when using `gsub`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub(/suffix\\z/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `gsub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.gsub!(/suffix\\z/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub(/suffix\\z/, 'foo')
+        RUBY
+      end
+
+      it 'does not register an offense and corrects when using `sub!`' do
+        expect_no_offenses(<<~RUBY)
+          str.sub!(/suffix\\z/, 'foo')
+        RUBY
+      end
+    end
+
+    it 'does not register an offense when using `delete_suffix`' do
       expect_no_offenses(<<~RUBY)
-        str.gsub(/pattern/, '')
+        str.delete_suffix('suffix')
       RUBY
     end
 
-    it 'does not register an offense when using `gsub!`' do
+    it 'does not register an offense when using `delete_suffix!`' do
       expect_no_offenses(<<~RUBY)
-        str.gsub!(/pattern/, '')
+        str.delete_suffix!('suffix')
       RUBY
     end
-
-    it 'does not register an offense when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/pattern/, '')
-      RUBY
-    end
-
-    it 'does not register an offense when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/pattern/, '')
-      RUBY
-    end
-  end
-
-  context 'with starting pattern `\A` and ending pattern `\z`' do
-    it 'does not register an offense and corrects when using `gsub`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub(/\\Asuffix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `gsub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub!(/\\Asuffix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/\\Asuffix\\z/, '')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/\\Asuffix\\z/, '')
-      RUBY
-    end
-  end
-
-  context 'when using a non-blank string as replacement string' do
-    it 'does not register an offense and corrects when using `gsub`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub(/suffix\\z/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `gsub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.gsub!(/suffix\\z/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub(/suffix\\z/, 'foo')
-      RUBY
-    end
-
-    it 'does not register an offense and corrects when using `sub!`' do
-      expect_no_offenses(<<~RUBY)
-        str.sub!(/suffix\\z/, 'foo')
-      RUBY
-    end
-  end
-
-  it 'does not register an offense when using `delete_suffix`' do
-    expect_no_offenses(<<~RUBY)
-      str.delete_suffix('suffix')
-    RUBY
-  end
-
-  it 'does not register an offense when using `delete_suffix!`' do
-    expect_no_offenses(<<~RUBY)
-      str.delete_suffix!('suffix')
-    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -1,110 +1,121 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :config do
-  RuboCop::Cop::Performance::RedundantEqualityComparisonBlock::TARGET_METHODS.each do |method_name|
-    it "registers and corrects an offense when using `#{method_name}` with `===` comparison block" do
-      expect_offense(<<~RUBY, method_name: method_name)
-        items.#{method_name} { |item| pattern === item }
-              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(pattern)` instead of block.
+  context 'when TargetRubyVersion >= 2.5', :ruby25 do
+    RuboCop::Cop::Performance::RedundantEqualityComparisonBlock::TARGET_METHODS.each do |method_name|
+      it "registers and corrects an offense when using `#{method_name}` with `===` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| pattern === item }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(pattern)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(pattern)
+        RUBY
+      end
+
+      it "registers and corrects an offense when using `#{method_name}` with `==` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item == other }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(other)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(other)
+        RUBY
+      end
+
+      it "registers and corrects an offense when using `#{method_name}` with `is_a?` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item.is_a?(Klass) }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(Klass)
+        RUBY
+      end
+
+      it "registers and corrects an offense when using `#{method_name}` with `kind_of?` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item.kind_of?(Klass) }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(Klass)
+        RUBY
+      end
+
+      it "does not register an offense when using `#{method_name}` with `===` comparison block and" \
+         'block argument is not used as a receiver for `===`' do
+        expect_no_offenses(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item === pattern }
+        RUBY
+      end
+    end
+
+    it 'registers and corrects an offense when using method chanin and `all?` with `===` comparison block' do
+      expect_offense(<<~RUBY)
+        items.do_something.all? { |item| item == other }
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `all?(other)` instead of block.
       RUBY
 
       expect_correction(<<~RUBY)
-        items.#{method_name}(pattern)
+        items.do_something.all?(other)
       RUBY
     end
 
-    it "registers and corrects an offense when using `#{method_name}` with `==` comparison block" do
-      expect_offense(<<~RUBY, method_name: method_name)
-        items.#{method_name} { |item| item == other }
-              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(other)` instead of block.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        items.#{method_name}(other)
+    it 'does not register an offense when using `all?` without `===` comparison block' do
+      expect_no_offenses(<<~RUBY)
+        items.all?(other)
       RUBY
     end
 
-    it "registers and corrects an offense when using `#{method_name}` with `is_a?` comparison block" do
-      expect_offense(<<~RUBY, method_name: method_name)
-        items.#{method_name} { |item| item.is_a?(Klass) }
-              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        items.#{method_name}(Klass)
+    it 'does not register an offense when using multiple block arguments' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |key, _value| key == other }
       RUBY
     end
 
-    it "registers and corrects an offense when using `#{method_name}` with `kind_of?` comparison block" do
-      expect_offense(<<~RUBY, method_name: method_name)
-        items.#{method_name} { |item| item.kind_of?(Klass) }
-              ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(Klass)` instead of block.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        items.#{method_name}(Klass)
+    it 'does not register an offense when using block argument is used for an argument of `is_a`' do
+      expect_no_offenses(<<~RUBY)
+        klasses.all? { |klass| item.is_a?(klass) }
       RUBY
     end
 
-    it "does not register an offense when using `#{method_name}` with `===` comparison block and" \
-       'block argument is not used as a receiver for `===`' do
-      expect_no_offenses(<<~RUBY, method_name: method_name)
-        items.#{method_name} { |item| item === pattern }
+    it 'does not register an offense when using block argument is used for an argument of `kind_of?`' do
+      expect_no_offenses(<<~RUBY)
+        klasses.all? { |klass| item.kind_of?(klass) }
+      RUBY
+    end
+
+    it 'does not register an offense when using block argument is not used as it is' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |item| item.do_something == other }
+      RUBY
+    end
+
+    it 'does not register an offense when using one argument with comma separator in block argument' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |item,| item == other }
+      RUBY
+    end
+
+    it 'does not register an offense when using not target methods with `===` comparison block' do
+      expect_no_offenses(<<~RUBY)
+        items.do_something { |item| item == other }
       RUBY
     end
   end
 
-  it 'registers and corrects an offense when using method chanin and `all?` with `===` comparison block' do
-    expect_offense(<<~RUBY)
-      items.do_something.all? { |item| item == other }
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `all?(other)` instead of block.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      items.do_something.all?(other)
-    RUBY
-  end
-
-  it 'does not register an offense when using `all?` without `===` comparison block' do
-    expect_no_offenses(<<~RUBY)
-      items.all?(other)
-    RUBY
-  end
-
-  it 'does not register an offense when using multiple block arguments' do
-    expect_no_offenses(<<~RUBY)
-      items.all? { |key, _value| key == other }
-    RUBY
-  end
-
-  it 'does not register an offense when using block argument is used for an argument of `is_a`' do
-    expect_no_offenses(<<~RUBY)
-      klasses.all? { |klass| item.is_a?(klass) }
-    RUBY
-  end
-
-  it 'does not register an offense when using block argument is used for an argument of `kind_of?`' do
-    expect_no_offenses(<<~RUBY)
-      klasses.all? { |klass| item.kind_of?(klass) }
-    RUBY
-  end
-
-  it 'does not register an offense when using block argument is not used as it is' do
-    expect_no_offenses(<<~RUBY)
-      items.all? { |item| item.do_something == other }
-    RUBY
-  end
-
-  it 'does not register an offense when using one argument with comma separator in block argument' do
-    expect_no_offenses(<<~RUBY)
-      items.all? { |item,| item == other }
-    RUBY
-  end
-
-  it 'does not register an offense when using not target methods with `===` comparison block' do
-    expect_no_offenses(<<~RUBY)
-      items.do_something { |item| item == other }
-    RUBY
+  context 'when TargetRubyVersion <= 2.4', :ruby24 do
+    # Ruby 2.4 does not support `items.all?(Klass)`.
+    it 'does not register an offense when using `all?` with `is_a?` comparison block' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |item| item.is_a?(Klass) }
+      RUBY
+    end
   end
 
   it 'does not register an offense when using block argument is used for an argument of RHS operand' do


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10632.

Reverts #232 and https://github.com/rubocop/rubocop-performance/commit/e3c374b.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
