### PR TITLE
[Fix #289] Fix a false positive for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_string_identifier_argument.md
+++ b/changelog/fix_a_false_positive_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#289](https://github.com/rubocop/rubocop-performance/issues/289): Fix a false positive for `Performance/StringIdentifierArgument` when using namespaced class string argument. ([@koic][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -46,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless (first_argument = node.first_argument)
           return unless first_argument.str_type?
-          return if first_argument.value.include?(' ')
+          return if first_argument.value.include?(' ') || first_argument.value.include?('::')
 
           replacement = first_argument.value.to_sym.inspect
 

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
     RUBY
   end
 
+  it 'does not register an offense when using cbase class string argument' do
+    expect_no_offenses(<<~RUBY)
+      Object.const_defined?('::Foo')
+    RUBY
+  end
+
+  it 'does not register an offense when using namespaced class string argument' do
+    expect_no_offenses(<<~RUBY)
+      Object.const_defined?('Foo::Bar')
+    RUBY
+  end
+
   it 'does not register an offense when using symbol argument for no identifier argument' do
     expect_no_offenses(<<~RUBY)
       foo('do_something')


### PR DESCRIPTION
Fixes #289.

This PR fixes a false positive for `Performance/StringIdentifierArgument` when using namespaced class string argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
