### PR TITLE
Fix `Performance/MapCompact` autocorrect causing invalid syntax 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,3 +362,4 @@
 [@mvz]: https://github.com/mvz
 [@leoarnold]: https://github.com/leoarnold
 [@ydah]: https://github.com/ydah
+[@QQism]: https://github.com/QQism

--- a/changelog/fix_performance_mapcompact_autocorrect_causing_invalid_syntax.md
+++ b/changelog/fix_performance_mapcompact_autocorrect_causing_invalid_syntax.md
@@ -1,0 +1,1 @@
+* [#291](https://github.com/rubocop/rubocop-performance/pull/291): Fix `Performance/MapCompact` autocorrect causing invalid syntax when using multiline `map { ... }.compact` as an argument for an assignment method. ([@QQism][])

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -83,7 +83,7 @@ module RuboCop
         end
 
         def invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
-          compact_node.loc.selector.line == chained_method.loc.selector.line
+          compact_node.loc.selector.line == chained_method.loc.last_line
         end
 
         def compact_method_with_final_newline_range(compact_method_range)

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -248,6 +248,19 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using multiline `map { ... }.compact` as an argument of an assignment method' do
+      expect_offense(<<~RUBY)
+        object.new_collection = collection.map do |item|
+                                           ^^^^^^^^^^^^^ Use `filter_map` instead.
+        end.compact
+      RUBY
+
+      expect_correction(<<~RUBY)
+        object.new_collection = collection.filter_map do |item|
+        end
+      RUBY
+    end
+
     it 'does not register an offense when using `collection.map(&:do_something).compact!`' do
       expect_no_offenses(<<~RUBY)
         collection.map(&:do_something).compact!


### PR DESCRIPTION
This commit fixes the issue when `Performance/MapCompact` auto-correction
fails to detect the argument block of an assignment method so it deletes
the block ending (i.e. `end` or `}`) when `map { ... }.compact` is
multiline.

#### Before

```ruby
object.new_collection = collection.map do |item|
end.compact

# auto-corrected
object.new_collection = collection.filter_map do |item|
```

#### After

```ruby
object.new_collection = collection.map do |item|
end.compact

# auto-corrected
object.new_collection = collection.filter_map do |item|
end
```

----

#### Rubocop Version

```
rubocop -V
1.28.2 (using Parser 3.1.2.0, rubocop-ast 1.18.0, running on ruby 3.0.1 x86_64-darwin20)
  - rubocop-performance 1.14.0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
