### PR TITLE
Fix a false positive for `Performance/RegexpMatch`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_regexp_match.md
+++ b/changelog/fix_a_false_positive_for_performance_regexp_match.md
@@ -1,0 +1,1 @@
+* [#292](https://github.com/rubocop/rubocop-performance/pull/292): Fix a false positive for `Performance/RegexpMatch` when `TargetRubyVersion: 2.3`. ([@koic][])

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -74,6 +74,9 @@ module RuboCop
       #   end
       class RegexpMatch < Base
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.4
 
         # Constants are included in this list because it is unlikely that
         # someone will store `nil` as a constant and then use it for comparison

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -423,4 +423,13 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
       end
     RUBY
   end
+
+  context 'when Ruby <= 2.3', :ruby23 do
+    it 'does not register an offense when using `String#match` in condition' do
+      expect_no_offenses(<<~RUBY)
+        if 'foo'.match(re)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-performance/pull/288#issuecomment-1148453972.

This PR fixes a false positive for `Performance/RegexpMatch` when `TargetRubyVersion: 2.3`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
