### PR TITLE
Fix a false negative for `Performance/ChainArrayAllocation` 

### DIFF
--- a/changelog/fix_false_negative_for_performance_chain_array_allocation.md
+++ b/changelog/fix_false_negative_for_performance_chain_array_allocation.md
@@ -1,0 +1,1 @@
+* [#294](https://github.com/rubocop/rubocop-performance/pull/294): Fix a false negative for `Performance/ChainArrayAllocation` when using `array.first(do_something).uniq`. ([@koic][])

--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -53,7 +53,7 @@ module RuboCop
 
         def_node_matcher :chain_array_allocation?, <<~PATTERN
           (send {
-            (send _ $%RETURN_NEW_ARRAY_WHEN_ARGS {int lvar ivar cvar gvar})
+            (send _ $%RETURN_NEW_ARRAY_WHEN_ARGS {int lvar ivar cvar gvar send})
             (block (send _ $%ALWAYS_RETURNS_NEW_ARRAY) ...)
             (send _ $%RETURNS_NEW_ARRAY ...)
           } $%HAS_MUTATION_ALTERNATIVE ...)

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
                                     ^^^^^ Use unchained `first` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
       RUBY
     end
+
+    it 'registers an offense for `first(do_something).uniq`' do
+      expect_offense(<<~RUBY)
+        [1, 2, 3, 4].first(do_something).uniq
+                                        ^^^^^ Use unchained `first` and `uniq!` (followed by `return array` if required) instead of chaining `first...uniq`.
+      RUBY
+    end
   end
 
   describe 'methods that only return an array with no block' do


### PR DESCRIPTION
This PR fixes a false negative for `Performance/ChainArrayAllocation` when using `array.first(do_something).uniq`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
