### PR TITLE
Fix a false negative for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_a_false_negative_for_performance_string_identifier_argument.md
+++ b/changelog/fix_a_false_negative_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#296](https://github.com/rubocop/rubocop-performance/pull/296): Fix a false negative for `Performance/StringIdentifierArgument` when using `instance_variable_defined?`. ([@koic][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -38,7 +38,7 @@ module RuboCop
           remove_class_variable remove_method undef_method class_variable_get class_variable_set
           deprecate_constant module_function private private_constant protected public public_constant
           remove_const ruby2_keywords
-          define_singleton_method instance_variable_defined instance_variable_get instance_variable_set
+          define_singleton_method instance_variable_defined? instance_variable_get instance_variable_set
           method public_method public_send remove_instance_variable respond_to? send singleton_method
           __send__
         ].freeze


### PR DESCRIPTION
This PR fixes a false negative for `Performance/StringIdentifierArgument` when using `instance_variable_defined?`.
It was due to a typo. I checked other method names and it seems that there is no problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
