### PR TITLE
Support autocorrection on `Performance/RedundantMatch` when receiver is a Regexp literal

### DIFF
--- a/changelog/change_support_autocorrection_on_redundantmatch.md
+++ b/changelog/change_support_autocorrection_on_redundantmatch.md
@@ -1,0 +1,1 @@
+* [#297](https://github.com/rubocop/rubocop-performance/pull/297): Support autocorrection on `Performance/RedundantMatch` when receiver is a Regexp literal. ([@r7kamura][])

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -41,20 +41,22 @@ module RuboCop
                         !(node.parent && node.parent.block_type?)
 
           add_offense(node) do |corrector|
-            autocorrect(corrector, node)
+            autocorrect(corrector, node) if autocorrectable?(node)
           end
         end
 
         private
 
         def autocorrect(corrector, node)
-          # Regexp#match can take a second argument, but this cop doesn't
-          # register an offense in that case
-          return unless node.first_argument.regexp_type?
-
           new_source = "#{node.receiver.source} =~ #{node.first_argument.source}"
 
           corrector.replace(node.source_range, new_source)
+        end
+
+        def autocorrectable?(node)
+          # Regexp#match can take a second argument, but this cop doesn't
+          # register an offense in that case
+          node.receiver.regexp_type? || node.first_argument.regexp_type?
         end
       end
     end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -111,4 +111,15 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch, :config do
                    ^^^^^^^^^^^^^^^^^^ Use `=~` in places where the `MatchData` returned by `#match` will not be used.
     RUBY
   end
+
+  it 'registers an offense and corrects when receiver is a Regexp literal' do
+    expect_offense(<<~RUBY)
+      something if /regex/.match(str)
+                   ^^^^^^^^^^^^^^^^^^ Use `=~` in places where the `MatchData` returned by `#match` will not be used.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      something if /regex/ =~ str
+    RUBY
+  end
 end


### PR DESCRIPTION
I found the following pattern is treated as an offense but not autocorrected, so tried to support it.

```ruby
# bad
something if /regexp/.match(string)

# good
something if /regexp/ =~ string
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
