### PR TITLE
Fix incorrect documentation URLs when using `rubocop --show-docs-url`

### DIFF
--- a/changelog/fix_incorrect_documentation_urls.md
+++ b/changelog/fix_incorrect_documentation_urls.md
@@ -1,0 +1,1 @@
+* [#299](https://github.com/rubocop/rubocop-performance/pull/299): Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,9 @@
 # This is the default configuration file.
 
+Performance:
+  Enabled: true
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-performance
+
 Performance/AncestorsInclude:
   Description: 'Use `A <= B` instead of `A.ancestors.include?(B)`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#ancestorsinclude-vs--code'


### PR DESCRIPTION
Added `DocumentationBaseURL` for `rubocop --show-docs-url [COP1,COP2,...]` command to work correctly for rubocop-performance cops.

### Before

```console
$ bundle exec rubocop --show-docs-url Performance/AncestorsInclude
https://docs.rubocop.org/rubocop/cops_performance.html#performanceancestorsinclude
```

### After

```console
$ bundle exec rubocop --show-docs-url Performance/AncestorsInclude
https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceancestorsinclude
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
