### PR TITLE
Use `cimg/ruby` instead of deprecated `circleci/ruby` image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       image:
         description: "Name of the Docker image."
         type: string
-        default: "circleci/ruby"
+        default: "cimg/ruby:3.1"
     docker:
       - image: << parameters.image >>
     environment:
@@ -23,7 +23,7 @@ jobs:
   # Miscellaneous tasks
   documentation-checks:
     docker:
-      - image: circleci/ruby
+      - image: cimg/ruby:3.1
     steps:
       - checkout
       - run: bundle install


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-performance/commit/f2b1319f.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
