### PR TITLE
Use `jruby` instead of `circleci/jruby` images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,4 +52,4 @@ workflows:
           image: rubocophq/circleci-ruby-snapshot:latest # Nightly snapshot build
       - rake_default:
           name: JRuby 9.3
-          image: circleci/jruby:9.3
+          image: jruby:9.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    env:
+      # See https://github.com/tmm1/test-queue#environment-variables
+      TEST_QUEUE_WORKERS: 2
+      JRUBY_OPTS: "--dev -J-Xmx1000M"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head', 'jruby-9.4']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: internal_investigation
+        run: bundle exec rake internal_investigation
+      - name: spec
+        run: bundle exec rake spec
+
+  check_documentation_syntax:
+    runs-on: ubuntu-latest
+    name: Check documentation syntax
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec rake documentation_syntax_check


### PR DESCRIPTION
This update is similar to https://github.com/rubocop/rubocop/pull/10326.
https://hub.docker.com/r/circleci/jruby hasn't been updated in a while.

The quickest way to get new resource is to be able to use official image.
https://hub.docker.com/_/jruby

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
