### PR TITLE
Change `Performance/StringInclude` autocorrection to use safe navigation operator

### DIFF
--- a/changelog/change_performance_string_include.md
+++ b/changelog/change_performance_string_include.md
@@ -1,0 +1,1 @@
+* [#303](https://github.com/rubocop/rubocop-performance/pull/303): Change `Performance/StringInclude` autocorrection to use safe navigation operator. ([@r7kamura][])

--- a/spec/rubocop/cop/performance/string_include_spec.rb
+++ b/spec/rubocop/cop/performance/string_include_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        str.include?('abc')
+        str&.include?('abc')
       RUBY
     end
 
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          str.include?("\\#{str}")
+          str&.include?("\\#{str}")
         RUBY
       end
 
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          str.include?('#{str}')
+          str&.include?('#{str}')
         RUBY
       end
 
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
         RUBY
 
         expect_correction(<<~RUBY)
-          str.include?('#{str}')
+          str&.include?('#{str}')
         RUBY
       end
 
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
       RUBY
 
       expect_correction(<<~RUBY)
-        str.include?('\\\\')
+        str&.include?('\\\\')
       RUBY
     end
 


### PR DESCRIPTION
As explained in its safety section, the autocorrection of this cop will significantly change the behavior of the code if the receiver is `nil`. I tried to use this cop's autocorrection on our Rails app, but this is the reason we couldn't apply autocorrect.

This problem can be avoided if the safe navigation operator is carefully used. It may be useless in some cases and is not a perfect solution, but it would be better than remaining possibility of `NoMethodError`. What do you think?

Note that there is another similar cop `Performance/StartWith`, which has the same issue with this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
