### PR TITLE
Support autocorrection even if `reject` is used on `Performance/Count`

### DIFF
--- a/changelog/change_support_autocorrection_even_if_reject_is_used.md
+++ b/changelog/change_support_autocorrection_even_if_reject_is_used.md
@@ -1,0 +1,1 @@
+* [#307](https://github.com/rubocop/rubocop-performance/pull/307): Support autocorrection even if `reject` is used on `Performance/Count`. ([@r7kamura][])

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -177,101 +177,166 @@ RSpec.describe RuboCop::Cop::Performance::Count, :config do
     end
   end
 
-  context 'autocorrect' do
-    context 'will correct' do
-      it 'select..size to count' do
-        expect_offense(<<~RUBY)
-          [1, 2].select { |e| e > 2 }.size
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...size`.
-        RUBY
+  context 'with `select` and `size`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.select { |e| e > 2 }.size
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...size`.
+      RUBY
 
-        expect_correction(<<~RUBY)
-          [1, 2].count { |e| e > 2 }
-        RUBY
-      end
-
-      it 'select..count without a block to count' do
-        expect_offense(<<~RUBY)
-          [1, 2].select { |e| e > 2 }.count
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...count`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          [1, 2].count { |e| e > 2 }
-        RUBY
-      end
-
-      it 'select..length to count' do
-        expect_offense(<<~RUBY)
-          [1, 2].select { |e| e > 2 }.length
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...length`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          [1, 2].count { |e| e > 2 }
-        RUBY
-      end
-
-      it 'select...size when select has parameters' do
-        expect_offense(<<~RUBY)
-          Data = Struct.new(:value)
-          array = [Data.new(2), Data.new(3), Data.new(2)]
-          puts array.select(&:value).size
-                     ^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...size`.
-        RUBY
-
-        expect_correction(<<~RUBY)
-          Data = Struct.new(:value)
-          array = [Data.new(2), Data.new(3), Data.new(2)]
-          puts array.count(&:value)
-        RUBY
-      end
+      expect_correction(<<~RUBY)
+        array.count { |e| e > 2 }
+      RUBY
     end
+  end
 
-    describe 'will not correct' do
-      it 'reject...size' do
-        expect_offense(<<~RUBY)
-          [1, 2].reject { |e| e > 2 }.size
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...size`.
-        RUBY
+  context 'with `select` and `count`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.select { |e| e > 2 }.count
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...count`.
+      RUBY
 
-        expect_no_corrections
-      end
+      expect_correction(<<~RUBY)
+        array.count { |e| e > 2 }
+      RUBY
+    end
+  end
 
-      it 'reject...count' do
-        expect_offense(<<~RUBY)
-          [1, 2].reject { |e| e > 2 }.count
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...count`.
-        RUBY
+  context 'with `select` and `length`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.select { |e| e > 2 }.length
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...length`.
+      RUBY
 
-        expect_no_corrections
-      end
+      expect_correction(<<~RUBY)
+        array.count { |e| e > 2 }
+      RUBY
+    end
+  end
 
-      it 'reject...length' do
-        expect_offense(<<~RUBY)
-          [1, 2].reject { |e| e > 2 }.length
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...length`.
-        RUBY
+  context 'with `select` with symbol block argument and `size`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.select(&:value).size
+              ^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `select...size`.
+      RUBY
 
-        expect_no_corrections
-      end
+      expect_correction(<<~RUBY)
+        array.count(&:value)
+      RUBY
+    end
+  end
 
-      it 'select...count when count has a block' do
-        expect_no_offenses(<<~RUBY)
-          [1, 2].select { |e| e > 2 }.count { |e| e.even? }
-        RUBY
-      end
+  context 'with `reject` and `size`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject { |e| e > 2 }.size
+              ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...size`.
+      RUBY
 
-      it 'reject...size when select has parameters' do
-        expect_offense(<<~RUBY)
-          Data = Struct.new(:value)
-          array = [Data.new(2), Data.new(3), Data.new(2)]
-          puts array.reject(&:value).size
-                     ^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...size`.
-        RUBY
+      expect_correction(<<~RUBY)
+        array.count { |e| !(e > 2) }
+      RUBY
+    end
+  end
 
-        expect_no_corrections
-      end
+  context 'with `reject` and `count`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject { |e| e > 2 }.count
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...count`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count { |e| !(e > 2) }
+      RUBY
+    end
+  end
+
+  context 'with `reject` and `length`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject { |e| e > 2 }.length
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...length`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count { |e| !(e > 2) }
+      RUBY
+    end
+  end
+
+  context 'with `reject` with symbol block argument and `size`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject(&:value).size
+              ^^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...size`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count { |element| !element.value }
+      RUBY
+    end
+  end
+
+  context 'with `reject` with variable block argument and `size`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject(&block).size
+              ^^^^^^^^^^^^^^^^^^^ Use `count` instead of `reject...size`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count { !block.call }
+      RUBY
+    end
+  end
+
+  context 'with `reject` with some statements and `length`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject {
+              ^^^^^^^^ Use `count` instead of `reject...length`.
+          foo
+          bar
+        }.length
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count {
+          foo
+          !(bar)
+        }
+      RUBY
+    end
+  end
+
+  context 'with `reject` with some conditional statement and `length`' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        array.reject {
+              ^^^^^^^^ Use `count` instead of `reject...length`.
+          foo
+          if bar
+            baz
+          else
+            qux
+          end
+        }.length
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.count {
+          foo
+          !(if bar
+            baz
+          else
+            qux
+          end)
+        }
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Until now, autocorrect was given up when reject was used, but it is now supported.

```ruby
# bad
array.reject { |e| e > 2 }.size

# good
array.count { |e| !(e > 2) }
```

```ruby
# bad
array.reject { |e| e > 2 }.count

# good
array.count { |e| !(e > 2) }
```

```ruby
# bad
array.reject { |e| e > 2 }.length

# good
array.count { |e| !(e > 2) }
```

```ruby
# bad
array.reject(&:value).size

# good
array.count { |element| !element.value }
```

```ruby
# bad
array.reject(&block).size

# good
array.count { !block.call }
```

```ruby
# bad
array.reject {
  foo
  bar
}.length

# good
array.count {
  foo
  !(bar)
}
```

The last one looks a bit weird but I think other cops autocorrects it to some other good form. If there is a better way to negate statements, I'd like to use it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
