### PR TITLE
Mark `Performance/RegexpMatch` as unsafe

### DIFF
--- a/changelog/change_mark_performanceregexpmatch_as_unsafe.md
+++ b/changelog/change_mark_performanceregexpmatch_as_unsafe.md
@@ -1,0 +1,1 @@
+* [#308](https://github.com/rubocop/rubocop-performance/pull/308): Mark `Performance/RegexpMatch` as unsafe. ([@r7kamura][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -266,7 +266,9 @@ Performance/RegexpMatch:
                   `Regexp#===`, or `=~` when `MatchData` is not used.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-'
   Enabled: true
+  Safe: false
   VersionAdded: '0.47'
+  VersionChanged: '<<next>>'
 
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -9,6 +9,10 @@ module RuboCop
       # backref.
       # So, when `MatchData` is not used, use `match?` instead of `match`.
       #
+      # @safety
+      #   This cop is unsafe because subsequent code may require the last
+      #   `MatchData` through `Regexp.last_match`, `$~`, etc.
+      #
       # @example
       #   # bad
       #   def foo


### PR DESCRIPTION
I think that this Cop is not always safe for the same reason as described in the `@safety` section.

```
$ irb
irb(main):001:0> "foo".match?(/(o)/)
=> true
irb(main):002:0> Regexp.last_match
=> nil
irb(main):003:0> "foo" =~ /(o)/
=> 1
irb(main):004:0> Regexp.last_match
=> #<MatchData "o" 1:"o">
```

Whether it is good practice or not, it is not always a mistake, as it is sometimes written with the expectation that `Regexp.last_match` can be used there.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
