### PR TITLE
[Fix #309] Fix an error for `Performance/MapCompact`

### DIFF
--- a/changelog/fix_an_error_for_performance_map_compact.md
+++ b/changelog/fix_an_error_for_performance_map_compact.md
@@ -1,0 +1,1 @@
+* [#309](https://github.com/rubocop/rubocop-performance/issues/309): Fix an error for `Performance/MapCompact` when using `map(&:do_something).compact` and there is a line break after `map.compact` and assigning with `||=`. ([@koic][])

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -67,7 +67,7 @@ module RuboCop
         def remove_compact_method(corrector, map_node, compact_node, chained_method)
           compact_method_range = compact_node.loc.selector
 
-          if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) && chained_method.dot? &&
+          if compact_node.multiline? && chained_method&.loc.respond_to?(:selector) && use_dot?(chained_method) &&
              !map_method_and_compact_method_on_same_line?(map_node, compact_node) &&
              !invoke_method_after_map_compact_on_same_line?(compact_node, chained_method)
             compact_method_range = compact_method_with_final_newline_range(compact_method_range)
@@ -76,6 +76,10 @@ module RuboCop
           end
 
           corrector.remove(compact_method_range)
+        end
+
+        def use_dot?(node)
+          node.respond_to?(:dot?) && node.dot?
         end
 
         def map_method_and_compact_method_on_same_line?(map_node, compact_node)

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -119,6 +119,20 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
+    it 'registers an offense when using `map(&:do_something).compact` and there is a line break after' \
+       '`map.compact` and assigning with `||=`' do
+      expect_offense(<<~RUBY)
+        foo[1] ||= collection
+                   .map(&:do_something).compact
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo[1] ||= collection
+                   .filter_map(&:do_something)
+      RUBY
+    end
+
     it 'registers an offense when using `map { ... }.compact.first` with single-line method calls' do
       expect_offense(<<~RUBY)
         collection.map { |item| item.do_something }.compact.first


### PR DESCRIPTION
Fixes #309.

This PR fixes an error for `Performance/MapCompact` when using `map(&:do_something).compact` and there is a line break after `map.compact` and assigning with `||=`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
