### PR TITLE
[Fix #313] Fix a false negative for `Performance/RedundantStringChars`

### DIFF
--- a/changelog/fix_a_false_negative_for_performance_redundant_string_chars.md
+++ b/changelog/fix_a_false_negative_for_performance_redundant_string_chars.md
@@ -1,0 +1,1 @@
+* [#313](https://github.com/rubocop/rubocop-performance/issues/313): Fix a false negative for `Performance/RedundantStringChars` when using `str.chars.last` without argument. ([@koic][])

--- a/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
@@ -67,9 +67,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantStringChars, :config do
     RUBY
   end
 
-  it 'does not register an offense when using `str.chars.last`' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense and corrects when using `str.chars.last`' do
+    expect_offense(<<~RUBY)
       str.chars.last
+          ^^^^^^^^^^ Use `[-1]` instead of `chars.last`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      str[-1]
     RUBY
   end
 


### PR DESCRIPTION
Fixes #313.

This PR fixes a false negative for `Performance/RedundantStringChars` when using `str.chars.last` without argument.

Report #249 has `str.chars.last(2)` argument. #250 mistakenly changed even without arguments `str.chars.last`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
