### PR TITLE
Extend `Performance/StringInclude` to handle `!~`

### DIFF
--- a/changelog/change_string_include_handle_not_match.md
+++ b/changelog/change_string_include_handle_not_match.md
@@ -1,0 +1,1 @@
+* [#318](https://github.com/rubocop/rubocop-performance/issues/318): Extend `Performance/StringInclude` to handle `!~`. ([@fatkodima][])

--- a/spec/rubocop/cop/performance/string_include_spec.rb
+++ b/spec/rubocop/cop/performance/string_include_spec.rb
@@ -157,4 +157,15 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
   it 'allows argument of `match?` is not a string literal' do
     expect_no_offenses('/ /.match?(content_as_symbol)')
   end
+
+  it 'registers an offense and corrects when using `!~`' do
+    expect_offense(<<~RUBY)
+      str !~ /abc/
+      ^^^^^^^^^^^^ Use `!String#include?` instead of a regex match with literal-only pattern.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      !str.include?('abc')
+    RUBY
+  end
 end


### PR DESCRIPTION
Closes #318.