### PR TITLE
Fix `Performance/RegexpMatch` to handle `::Regexp`

### DIFF
--- a/changelog/fix_regexp_match_to_handle_cbase_regexp.md
+++ b/changelog/fix_regexp_match_to_handle_cbase_regexp.md
@@ -1,0 +1,1 @@
+* [#314](https://github.com/rubocop/rubocop-performance/issues/314): Fix `Performance/RegexpMatch` to handle `::Regexp`. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -124,8 +124,8 @@ module RuboCop
 
         def_node_search :last_matches, <<~PATTERN
           {
-            (send (const nil? :Regexp) :last_match)
-            (send (const nil? :Regexp) :last_match _)
+            (send (const {nil? cbase} :Regexp) :last_match)
+            (send (const {nil? cbase} :Regexp) :last_match _)
             ({back_ref nth_ref} _)
             (gvar #match_gvar?)
           }

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
     %w[
       $& $' $` $~ $1 $2 $100
       $MATCH
-      Regexp.last_match Regexp.last_match(1)
+      Regexp.last_match ::Regexp.last_match Regexp.last_match(1)
     ].each do |var|
       it "accepts #{name} in method with #{var}" do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes #314.