### PR TITLE
Fix a false positive for `Performance/Sum`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_sum.md
+++ b/changelog/fix_a_false_positive_for_performance_sum.md
@@ -1,0 +1,1 @@
+* [#321](https://github.com/rubocop/rubocop-performance/pull/321): Fix a false positive for `Performance/Sum` when using `TargetRubyVersion` is 2.3 or lower. ([@koic][])

--- a/lib/rubocop/cop/performance/sum.rb
+++ b/lib/rubocop/cop/performance/sum.rb
@@ -70,6 +70,9 @@ module RuboCop
       class Sum < Base
         include RangeHelp
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.4
 
         MSG = 'Use `%<good_method>s` instead of `%<bad_method>s`.'
         MSG_IF_NO_INIT_VALUE =

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -304,6 +304,14 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
         array.sum
       RUBY
     end
+
+    context 'when Ruby 2.3 or lower', :ruby23 do
+      it "does not register an offense when using `array.#{method}(10, :+)`" do
+        expect_no_offenses(<<~RUBY, method: method)
+          array.#{method}(10, :+)
+        RUBY
+      end
+    end
   end
 
   %i[map collect].each do |method|


### PR DESCRIPTION
This PR fixes a false positive for `Performance/Sum` when using `TargetRubyVersion` is 2.3 or lower.
Because `Array#sum` was introduced in Ruby 2.4.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
