### PR TITLE
Use concurrency for GitHub Actions workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,9 @@
 name: Linting
 on:
   - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   yamllint:
     name: Yamllint

--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -2,6 +2,10 @@ name: Spell Checking
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codespell:
     name: Check spelling of all files with codespell


### PR DESCRIPTION
Same as: https://github.com/rubocop/rubocop-rspec/pull/1539

This PR ensures that only the last execution per branch always works, even when pushed multiple times in a row, for example. The older one is canceled.

Refs:
https://docs.github.com/en/actions/using-jobs/using-concurrency https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [-] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
