### PR TITLE
Register offenses for variables against regexes in `Performance/StringInclude`

### DIFF
--- a/changelog/change_register_offenses_for_variables_against.md
+++ b/changelog/change_register_offenses_for_variables_against.md
@@ -1,0 +1,1 @@
+* [#332](https://github.com/rubocop/rubocop-performance/pull/332): Register offenses for variables against regexes in `Performance/StringInclude`. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/string_include.rb
+++ b/lib/rubocop/cop/performance/string_include.rb
@@ -6,19 +6,19 @@ module RuboCop
       # Identifies unnecessary use of a regex where `String#include?` would suffice.
       #
       # @safety
-      #   This cop's offenses are not safe to autocorrect if a receiver is nil.
+      #   This cop's offenses are not safe to autocorrect if a receiver is nil or a Symbol.
       #
       # @example
       #   # bad
-      #   'abc'.match?(/ab/)
-      #   /ab/.match?('abc')
-      #   'abc' =~ /ab/
-      #   /ab/ =~ 'abc'
-      #   'abc'.match(/ab/)
-      #   /ab/.match('abc')
+      #   str.match?(/ab/)
+      #   /ab/.match?(str)
+      #   str =~ /ab/
+      #   /ab/ =~ str
+      #   str.match(/ab/)
+      #   /ab/.match(str)
       #
       #   # good
-      #   'abc'.include?('ab')
+      #   str.include?('ab')
       class StringInclude < Base
         extend AutoCorrector
 
@@ -27,7 +27,7 @@ module RuboCop
 
         def_node_matcher :redundant_regex?, <<~PATTERN
           {(send $!nil? {:match :=~ :!~ :match?} (regexp (str $#literal?) (regopt)))
-           (send (regexp (str $#literal?) (regopt)) {:match :match?} $str)
+           (send (regexp (str $#literal?) (regopt)) {:match :match?} $_)
            (match-with-lvasgn (regexp (str $#literal?) (regopt)) $_)}
         PATTERN
 

--- a/spec/rubocop/cop/performance/string_include_spec.rb
+++ b/spec/rubocop/cop/performance/string_include_spec.rb
@@ -151,11 +151,11 @@ RSpec.describe RuboCop::Cop::Performance::StringInclude, :config do
     expect_no_offenses('expect(subject.spin).to match(/\A\n/)')
   end
 
-  # Symbol object does not have `include?` method.
-  # A variable possible to be a symbol object, so if `match?` argument is
-  # a variable, accept it.
-  it 'allows argument of `match?` is not a string literal' do
-    expect_no_offenses('/ /.match?(content_as_symbol)')
+  it 'registers an offense and corrects when argument of `match?` is not a string literal' do
+    expect_offense(<<~RUBY)
+      / /.match?(content)
+      ^^^^^^^^^^^^^^^^^^^ Use `String#include?` instead of a regex match with literal-only pattern.
+    RUBY
   end
 
   it 'registers an offense and corrects when using `!~`' do


### PR DESCRIPTION
See https://github.com/rails/rails/pull/46910.

The second pattern of `StringInclude#redundant_regex?`(`(send (regexp (str $#literal?) (regopt)) {:match :match?} $str)`) is pretty useless, because it only detects cases like `'str'.match?(/str/)`, so literal regex is matched against literal string. But does anyone write such code?

That pattern was implemented that way, because, to avoid cases when the receiver is a symbol and symbol does not implement `#include?`. But, it already marks as offense and autocorrects `can_be_a_symbol.match?(/abc/)`! So I think this PR changes are fair.