### PR TITLE
[Fix #336] Expand the safety warning on Performance/Detect

### DIFF
--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -8,9 +8,12 @@ module RuboCop
       # `detect` instead.
       #
       # @safety
-      #   This cop is unsafe because is has known compatibility issues with `ActiveRecord` and other
-      #   frameworks. `ActiveRecord` does not implement a `detect` method and `find` has its own
-      #   meaning. Correcting `ActiveRecord` methods with this cop should be considered unsafe.
+      #   This cop is unsafe because is assumes the class implements the
+      #   `Enumerable` interface, but can't reliably detect this. This creates
+      #   known compatibility issues with `Hash`, `ActiveRecord` and other
+      #   frameworks. `Hash` and `ActiveRecord` do not implement a `detect`
+      #   method and `find` has its own meaning. Correcting `Hash` and
+      #   `ActiveRecord` methods with this cop should be considered unsafe.
       #
       # @example
       #   # bad


### PR DESCRIPTION
In addition to the external library activerecord, the built in Hash class also has compatibility issues.

I'm unsure if this deserves a changelog entry, given it doesn't change the code there shouldn't be an impact (which is why I didn't add tests either).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] <del>Added tests.</del>
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/