### PR TITLE
Enhance `RedundantEqualityComparisonBlock` to check `=~` and `match?` methods

### DIFF
--- a/changelog/change_redundant_equality_comparison_block_additional_regexp_methods.md
+++ b/changelog/change_redundant_equality_comparison_block_additional_regexp_methods.md
@@ -1,0 +1,1 @@
+* [#339](https://github.com/rubocop/rubocop-performance/pull/339): Enhance `RedundantEqualityComparisonBlock` to check `=~` and `match?` methods. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -17,11 +17,14 @@ module RuboCop
       #   # bad
       #   items.all? { |item| pattern === item }
       #   items.all? { |item| item == other }
+      #   items.all? { |item| item =~ pattern }
       #   items.all? { |item| item.is_a?(Klass) }
       #   items.all? { |item| item.kind_of?(Klass) }
+      #   items.all? { |item| item.match?(pattern) }
       #
       #   # good
       #   items.all?(pattern)
+      #   items.all?(Klass)
       #
       class RedundantEqualityComparisonBlock < Base
         extend AutoCorrector
@@ -32,7 +35,7 @@ module RuboCop
         MSG = 'Use `%<prefer>s` instead of block.'
 
         TARGET_METHODS = %i[all? any? one? none?].freeze
-        COMPARISON_METHODS = %i[== === is_a? kind_of?].freeze
+        COMPARISON_METHODS = %i[== === =~ is_a? kind_of? match?].freeze
         IS_A_METHODS = %i[is_a? kind_of?].freeze
 
         def on_block(node)

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
         RUBY
       end
 
+      it "registers and corrects an offense when using `#{method_name}` with `=~` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item =~ other }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(other)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(other)
+        RUBY
+      end
+
       it "registers and corrects an offense when using `#{method_name}` with `is_a?` comparison block" do
         expect_offense(<<~RUBY, method_name: method_name)
           items.#{method_name} { |item| item.is_a?(Klass) }
@@ -44,6 +55,17 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
 
         expect_correction(<<~RUBY)
           items.#{method_name}(Klass)
+        RUBY
+      end
+
+      it "registers and corrects an offense when using `#{method_name}` with `match?` comparison block" do
+        expect_offense(<<~RUBY, method_name: method_name)
+          items.#{method_name} { |item| item.match?(pattern) }
+                ^{method_name}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method_name}(pattern)` instead of block.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          items.#{method_name}(pattern)
         RUBY
       end
 


### PR DESCRIPTION
Closes #339.

`Regexp#match` technically can be added too, but this can produce more false positives due to its name popularity 🤔 