### PR TITLE
Improve safety section on `Performance/Detect`

### DIFF
--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -8,12 +8,9 @@ module RuboCop
       # `detect` instead.
       #
       # @safety
-      #   This cop is unsafe because is assumes the class implements the
-      #   `Enumerable` interface, but can't reliably detect this. This creates
-      #   known compatibility issues with `Hash`, `ActiveRecord` and other
-      #   frameworks. `Hash` and `ActiveRecord` do not implement a `detect`
-      #   method and `find` has its own meaning. Correcting `Hash` and
-      #   `ActiveRecord` methods with this cop should be considered unsafe.
+      #   This cop is unsafe because it assumes that the receiver is an
+      #   `Array` or equivalent, but can't reliably detect it. For example,
+      #   if the receiver is a `Hash`, it may report a false positive.
       #
       # @example
       #   # bad


### PR DESCRIPTION
Since this cop tries to use `Array#reverse`, it would be better to explain that it depends on `Array`, not `Enumerable`. And I also thought that ActiveRecord (`ActiveRecord::Relation` to be exact) part should be removed from the description since there is no problem (anymore?).

Also see the comments on:

- https://github.com/rubocop/rubocop-performance/pull/337

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
