### PR TITLE
Fix `FlatMap` autocorrection for chained methods on separate lines

### DIFF
--- a/changelog/fix_flat_map_autocorrect_separate_lines.md
+++ b/changelog/fix_flat_map_autocorrect_separate_lines.md
@@ -1,0 +1,1 @@
+* [#344](https://github.com/rubocop/rubocop-performance/issues/344): Fix `Performance/FlatMap` autocorrection for chained methods on separate lines. ([@fatkodima][])

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe RuboCop::Cop::Performance::FlatMap, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when calling #{method}...#{flatten}(1) on separate lines" do
+      expect_offense(<<~RUBY, method: method, flatten: flatten)
+        [1, 2, 3, 4]
+          .#{method} { |e| [e, e] }
+           ^{method}^^^^^^^^^^^^^^^ Use `flat_map` instead of `#{method}...#{flatten}`.
+          .#{flatten}(1)
+          .size
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3, 4]
+          .flat_map { |e| [e, e] }
+          .size
+      RUBY
+    end
+
     it "registers an offense and corrects when calling #{method}(&:foo).#{flatten}(1)" do
       expect_offense(<<~RUBY, method: method, flatten: flatten)
         [1, 2, 3, 4].#{method}(&:foo).#{flatten}(1)
@@ -21,6 +37,22 @@ RSpec.describe RuboCop::Cop::Performance::FlatMap, :config do
 
       expect_correction(<<~RUBY)
         [1, 2, 3, 4].flat_map(&:foo)
+      RUBY
+    end
+
+    it "registers an offense and corrects when calling #{method}(&:foo).#{flatten}(1) on separate lines" do
+      expect_offense(<<~RUBY, method: method, flatten: flatten)
+        [1, 2, 3, 4]
+          .#{method}(&:foo)
+           ^{method}^^^^^^^ Use `flat_map` instead of `#{method}...#{flatten}`.
+          .#{flatten}(1)
+          .size
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1, 2, 3, 4]
+          .flat_map(&:foo)
+          .size
       RUBY
     end
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-performance/issues/344.
