### PR TITLE
[Fix #346] Fix a false positive for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_string_identifier_argument.md
+++ b/changelog/fix_a_false_positive_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#346](https://github.com/rubocop/rubocop-performance/issues/346): Fix a false positive for `Performance/StringIdentifierArgument` when using a command method with receiver. ([@koic][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -27,28 +27,33 @@ module RuboCop
 
         MSG = 'Use `%<symbol_arg>s` instead of `%<string_arg>s`.'
 
+        COMMAND_METHODS = %i[
+          alias_method attr_accessor attr_reader attr_writer autoload autoload? private private_constant
+          protected public public_constant module_function
+        ].freeze
+
         # NOTE: `attr` method is not included in this list as it can cause false positives in Nokogiri API.
         # And `attr` may not be used because `Style/Attr` registers an offense.
         # https://github.com/rubocop/rubocop-performance/issues/278
-        RESTRICT_ON_SEND = %i[
-          alias_method attr_accessor attr_reader attr_writer autoload autoload?
+        RESTRICT_ON_SEND = (%i[
           class_variable_defined? const_defined? const_get const_set const_source_location
           define_method instance_method method_defined? private_class_method? private_method_defined?
           protected_method_defined? public_class_method public_instance_method public_method_defined?
           remove_class_variable remove_method undef_method class_variable_get class_variable_set
-          deprecate_constant module_function private private_constant protected public public_constant
-          remove_const ruby2_keywords
-          define_singleton_method instance_variable_defined? instance_variable_get instance_variable_set
-          method public_method public_send remove_instance_variable respond_to? send singleton_method
-          __send__
-        ].freeze
+          deprecate_constant remove_const ruby2_keywords define_singleton_method instance_variable_defined?
+          instance_variable_get instance_variable_set method public_method public_send remove_instance_variable
+          respond_to? send singleton_method __send__
+        ] + COMMAND_METHODS).freeze
 
         def on_send(node)
+          return if COMMAND_METHODS.include?(node.method_name) && node.receiver
           return unless (first_argument = node.first_argument)
           return unless first_argument.str_type?
-          return if first_argument.value.include?(' ') || first_argument.value.include?('::')
 
-          replacement = first_argument.value.to_sym.inspect
+          first_argument_value = first_argument.value
+          return if first_argument_value.include?(' ') || first_argument_value.include?('::')
+
+          replacement = first_argument_value.to_sym.inspect
 
           message = format(MSG, symbol_arg: replacement, string_arg: first_argument.source)
 

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
     end
   end
 
+  RuboCop::Cop::Performance::StringIdentifierArgument::COMMAND_METHODS.each do |method|
+    it "does not register an offense when using string argument for `#{method}` method with receiver" do
+      expect_no_offenses(<<~RUBY)
+        obj.#{method}('do_something')
+      RUBY
+    end
+  end
+
   it 'does not register an offense when no arguments' do
     expect_no_offenses(<<~RUBY)
       send


### PR DESCRIPTION
Fixes #346.

This PR fixes a false positive for `Performance/StringIdentifierArgument` when using a command method with receiver. It makes that cop to allow some command methods that don't normally specify a receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
