### PR TITLE
Fix `AllowRegexpMatch` of `Performance/RedundantEqualityComparisonBlock` by default

### DIFF
--- a/changelog/fix_default_config_of_redundant_equality_comparison_block.md
+++ b/changelog/fix_default_config_of_redundant_equality_comparison_block.md
@@ -1,0 +1,1 @@
+* [#352](https://github.com/rubocop/rubocop-performance/pull/352): Fix the default config for `AllowRegexpMatch` option of `Performance/RedundantEqualityComparisonBlock`. ([@koic][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -226,7 +226,7 @@ Performance/RedundantEqualityComparisonBlock:
   Reference: 'https://github.com/rails/rails/pull/41363'
   Enabled: pending
   Safe: false
-  AllowRegexpMatch: false
+  AllowRegexpMatch: true
   VersionAdded: '1.10'
 
 Performance/RedundantMatch:

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -10,7 +10,7 @@ module RuboCop
       # behavior is appropriately overridden in subclass. For example,
       # `Range#===` returns `true` when argument is within the range.
       #
-      # This cop has `AllowRegexpMatch` option and it is false by default because
+      # This cop has `AllowRegexpMatch` option and it is true by default because
       # `regexp.match?('string')` often used in block changes to the opposite result:
       #
       # [source,ruby]


### PR DESCRIPTION
This PR fixes `AllowRegexpMatch` of `Performance/RedundantEqualityComparisonBlock` by default.

Default value is true as documented example below:
https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceredundantequalitycomparisonblock

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
