### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ workflows:
     jobs:
       - documentation-checks
       - rake_default:
-          name: Ruby 2.6
-          image: cimg/ruby:2.6
-      - rake_default:
           name: Ruby 2.7
           image: cimg/ruby:2.7
       - rake_default:
@@ -53,6 +50,3 @@ workflows:
       - rake_default:
           name: Ruby HEAD
           image: rubocophq/circleci-ruby-snapshot:latest # Nightly snapshot build
-      - rake_default:
-          name: JRuby 9.3
-          image: circleci/jruby:9.3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/changelog/change_drop_ruby_2_6_support.md
+++ b/changelog/change_drop_ruby_2_6_support.md
@@ -1,0 +1,1 @@
+* [#353](https://github.com/rubocop/rubocop-performance/pull/353): **(Breaking)** Drop Ruby 2.6 support. ([@koic][])

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-performance'
   s.version = RuboCop::Performance::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<~DESCRIPTION
     A collection of RuboCop cops to check for performance optimizations

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe 'RuboCop Performance Project', type: :feature do
 
       describe 'link to related issue' do
         let(:issues) do
-          entries.map do |entry|
+          entries.filter_map do |entry|
             entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^)]+)\)/)
-          end.compact
+          end
         end
 
         it 'has an issue number prefixed with #' do

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-if RUBY_VERSION < '2.6'
-  puts 'Changelog utilities available only for Ruby 2.6+'
-  exit(1)
-end
-
 # Changelog utility
 class Changelog
   ENTRIES_PATH = 'changelog/'


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11791.

This PR drops Ruby 2.6 support. And JRuby has been dropped from the CI matrix because no JRuby-specific issues have been found and prevents the following build error:

```console
#!/bin/bash -eo pipefail
bundle install
Fetching https://github.com/rubocop/rubocop.git
You need to install git to be able to use gems from git repositories. For help
installing git, please refer to GitHub's tutorial at
https://help.github.com/articles/set-up-git

Exited with code exit status 11
CircleCI received exit code 11
```

https://app.circleci.com/pipelines/github/rubocop/rubocop-minitest/926/workflows/68776b54-5856-4acd-a99a-f41df114634d/jobs/6034

This does not mean no support for JRuby. RuboCop Performance will continue to support JRuby 9.4+.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
