### PR TITLE
Fix an incorrect autocorrect for `Performance/ConstantRegexp` and `Performance/RegexpMatch` when autocorrecting both at the same time

### DIFF
--- a/changelog/fix_autocorrect_constant_regexp_and_regexp_match.md
+++ b/changelog/fix_autocorrect_constant_regexp_and_regexp_match.md
@@ -1,0 +1,1 @@
+* [#351](https://github.com/rubocop/rubocop-performance/issues/351): Fix an incorrect autocorrect for `Performance/ConstantRegexp` and `Performance/RegexpMatch` when autocorrecting both at the same time. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/constant_regexp.rb
+++ b/lib/rubocop/cop/performance/constant_regexp.rb
@@ -38,6 +38,10 @@ module RuboCop
 
         MSG = 'Extract this regexp into a constant, memoize it, or append an `/o` option to its options.'
 
+        def self.autocorrect_incompatible_with
+          [RegexpMatch]
+        end
+
         def on_regexp(node)
           return if within_allowed_assignment?(node) || !include_interpolated_const?(node) || node.single_interpolation?
 

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -131,6 +131,10 @@ module RuboCop
           }
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [ConstantRegexp]
+        end
+
         def on_if(node)
           check_condition(node.condition)
         end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'mock console output'
+
+  before do
+    RuboCop::ConfigLoader.default_configuration = nil
+    RuboCop::ConfigLoader.default_configuration.for_all_cops['SuggestExtensions'] = false
+    RuboCop::ConfigLoader.default_configuration.for_all_cops['NewCops'] = 'disable'
+  end
+
+  it 'corrects `Performance/ConstantRegexp` with `Performance/RegexpMatch`' do
+    create_file('.rubocop.yml', <<~YAML)
+      Performance/ConstantRegexp:
+        Enabled: true
+      Performance/RegexpMatch:
+        Enabled: true
+    YAML
+    source = <<~RUBY
+      foo if bar =~ /\#{CONSTANT}/
+    RUBY
+    create_file('example.rb', source)
+    expect(cli.run(['--autocorrect', '--only', 'Performance/ConstantRegexp,Performance/RegexpMatch'])).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      foo if /\#{CONSTANT}/o.match?(bar)
+    RUBY
+  end
+
+  private
+
+  def create_file(file_path, content)
+    file_path = File.expand_path(file_path)
+
+    dir_path = File.dirname(file_path)
+    FileUtils.mkdir_p(dir_path)
+
+    File.write(file_path, content)
+
+    file_path
+  end
+end


### PR DESCRIPTION
Fixes #351.