### PR TITLE
Add `sort!` and `minmax` to `Performance/CompareWithBlock`

### DIFF
--- a/changelog/change_compare_with_block_methods.md
+++ b/changelog/change_compare_with_block_methods.md
@@ -1,0 +1,1 @@
+* [#357](https://github.com/rubocop/rubocop-performance/pull/357): Add `sort!` and `minmax` to `Performance/CompareWithBlock`. ([@vlad-pisanov][])

--- a/spec/rubocop/cop/performance/compare_with_block_spec.rb
+++ b/spec/rubocop/cop/performance/compare_with_block_spec.rb
@@ -1,48 +1,48 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Performance::CompareWithBlock, :config do
-  shared_examples 'compare with block' do |method|
+  shared_examples 'compare with block' do |method, replacement|
     it "registers an offense and corrects for #{method}" do
       expect_offense(<<~RUBY, method: method)
         array.#{method} { |a, b| a.foo <=> b.foo }
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method}_by(&:foo)` instead of `#{method} { |a, b| a.foo <=> b.foo }`.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{replacement}(&:foo)` instead of `#{method} { |a, b| a.foo <=> b.foo }`.
       RUBY
 
       expect_correction(<<~RUBY)
-        array.#{method}_by(&:foo)
+        array.#{replacement}(&:foo)
       RUBY
     end
 
     it "registers an offense and corrects for #{method} with [:foo]" do
       expect_offense(<<~RUBY, method: method)
         array.#{method} { |a, b| a[:foo] <=> b[:foo] }
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method}_by { |a| a[:foo] }` instead of `#{method} { |a, b| a[:foo] <=> b[:foo] }`.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{replacement} { |a| a[:foo] }` instead of `#{method} { |a, b| a[:foo] <=> b[:foo] }`.
       RUBY
 
       expect_correction(<<~RUBY)
-        array.#{method}_by { |a| a[:foo] }
+        array.#{replacement} { |a| a[:foo] }
       RUBY
     end
 
     it "registers an offense and corrects for #{method} with ['foo']" do
       expect_offense(<<~RUBY, method: method)
         array.#{method} { |a, b| a['foo'] <=> b['foo'] }
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method}_by { |a| a['foo'] }` instead of `#{method} { |a, b| a['foo'] <=> b['foo'] }`.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{replacement} { |a| a['foo'] }` instead of `#{method} { |a, b| a['foo'] <=> b['foo'] }`.
       RUBY
 
       expect_correction(<<~RUBY)
-        array.#{method}_by { |a| a['foo'] }
+        array.#{replacement} { |a| a['foo'] }
       RUBY
     end
 
     it "registers an offense and corrects for #{method} with [1]" do
       expect_offense(<<~RUBY, method: method)
         array.#{method} { |a, b| a[1] <=> b[1] }
-              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{method}_by { |a| a[1] }` instead of `#{method} { |a, b| a[1] <=> b[1] }`.
+              ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^ Use `#{replacement} { |a| a[1] }` instead of `#{method} { |a, b| a[1] <=> b[1] }`.
       RUBY
 
       expect_correction(<<~RUBY)
-        array.#{method}_by { |a| a[1] }
+        array.#{replacement} { |a| a[1] }
       RUBY
     end
 
@@ -50,12 +50,14 @@ RSpec.describe RuboCop::Cop::Performance::CompareWithBlock, :config do
       expect_no_offenses("array.#{method} { |a, b| b <=> a }")
     end
 
-    it "accepts #{method}_by" do
-      expect_no_offenses("array.#{method}_by { |a| a.baz }")
+    it "accepts #{replacement}" do
+      expect_no_offenses("array.#{replacement} { |a| a.baz }")
     end
   end
 
-  include_examples 'compare with block', 'sort'
-  include_examples 'compare with block', 'max'
-  include_examples 'compare with block', 'min'
+  include_examples 'compare with block', 'sort',   'sort_by'
+  include_examples 'compare with block', 'sort!',  'sort_by!'
+  include_examples 'compare with block', 'max',    'max_by'
+  include_examples 'compare with block', 'min',    'min_by'
+  include_examples 'compare with block', 'minmax', 'minmax_by'
 end


### PR DESCRIPTION
`Performance/CompareWithBlock` currently only looks at `sort`, `min` and `max` usage.

This PR adds support for `sort!` and `minmax` methods which behave the same way.

```ruby
# bad
arr.minmax { |a, b| a.foo <=> b.foo }
arr.sort!  { |a, b| a.foo <=> b.foo }

# good
arr.minmax_by(&:foo)
arr.sort_by!(&:foo)
```

```
Comparison:
               minmax_by:  1513625.0 i/s
               minmax:     1178249.9 i/s - 1.28x  slower
```

```
Comparison:
               sort_by!:    21368.8 i/s
               sort!:       13662.7 i/s - 1.56x  slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
