### PR TITLE
[Fix #359] Fix a false positive for `Performance/RedundantEqualityComparisonBlock`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_redundant_equality_comparison_block.md
+++ b/changelog/fix_a_false_positive_for_performance_redundant_equality_comparison_block.md
@@ -1,0 +1,1 @@
+* [#359](https://github.com/rubocop/rubocop-performance/issues/359): Fix a false positive for `Performance/RedundantEqualityComparisonBlock` when the block variable is used on both sides of `==`. ([@koic][])

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -97,7 +97,7 @@ module RuboCop
           elsif IS_A_METHODS.include?(block_body.method_name)
             block_argument.source == block_body.first_argument.source
           else
-            false
+            block_body.receiver.source == block_body.first_argument.receiver&.source
           end
         end
 

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       RUBY
     end
 
+    it 'does not register an offense when the block variable is used on both sides of `==`' do
+      expect_no_offenses(<<~RUBY)
+        items.all? { |item| item == item.do_something }
+      RUBY
+    end
+
     it 'does not register an offense when using not target methods with `===` comparison block' do
       expect_no_offenses(<<~RUBY)
         items.do_something { |item| item == other }


### PR DESCRIPTION
Fixes #359.

This PR fixes a false positive for `Performance/RedundantEqualityComparisonBlock` when the block variable is used on both sides of `==`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
