### PR TITLE
[Fix #365] Fix false positives for `Performance/ArraySemiInfiniteRangeSlice`

### DIFF
--- a/changelog/fix_false_positives_for_performance_array_semi_infinite_range_slice.md
+++ b/changelog/fix_false_positives_for_performance_array_semi_infinite_range_slice.md
@@ -1,0 +1,1 @@
+* [#365](https://github.com/rubocop/rubocop-performance/issues/365): Fix false positives for `Performance/ArraySemiInfiniteRangeSlice` when using `[]` with string literals. ([@koic][])

--- a/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
+++ b/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
@@ -39,7 +39,7 @@ module RuboCop
         RESTRICT_ON_SEND = SLICE_METHODS
 
         def_node_matcher :endless_range_slice?, <<~PATTERN
-          (call $_ $%SLICE_METHODS $#endless_range?)
+          (call $!{str dstr xstr} $%SLICE_METHODS $#endless_range?)
         PATTERN
 
         def_node_matcher :endless_range?, <<~PATTERN

--- a/spec/rubocop/cop/performance/array_semi_infinite_range_slice_spec.rb
+++ b/spec/rubocop/cop/performance/array_semi_infinite_range_slice_spec.rb
@@ -77,5 +77,23 @@ RSpec.describe RuboCop::Cop::Performance::ArraySemiInfiniteRangeSlice, :config d
         array[-2..]
       RUBY
     end
+
+    it 'does not registers an offense when using `[]` with endless range for string literal' do
+      expect_no_offenses(<<~RUBY)
+        'str'[3..]
+      RUBY
+    end
+
+    it 'does not registers an offense when using `[]` with endless range for interpolated string literal' do
+      expect_no_offenses(<<~'RUBY')
+        "string#{interpolation}"[3..]
+      RUBY
+    end
+
+    it 'does not registers an offense when using `[]` with endless range for backquote string literal' do
+      expect_no_offenses(<<~RUBY)
+        `str`[3..]
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #365.

This PR fixes false positives for `Performance/ArraySemiInfiniteRangeSlice` when using `[]` with string literals.
What this can do is accept string literals, as they are already marked as unsafe.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
