### PR TITLE
[Fix #367] Fix an incorrect autocorrect for `Performance/BlockGivenWithExplicitBlock`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_performance_block_given_with_explicit_block.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_performance_block_given_with_explicit_block.md
@@ -1,0 +1,1 @@
+* [#367](https://github.com/rubocop/rubocop-performance/issues/367): Fix an incorrect autocorrect for `Performance/BlockGivenWithExplicitBlock` when using `Lint/UnusedMethodArgument`'s autocorrection together. ([@ymap][])

--- a/lib/rubocop-performance.rb
+++ b/lib/rubocop-performance.rb
@@ -9,3 +9,11 @@ require_relative 'rubocop/performance/inject'
 RuboCop::Performance::Inject.defaults!
 
 require_relative 'rubocop/cop/performance_cops'
+
+RuboCop::Cop::Lint::UnusedMethodArgument.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::Performance::BlockGivenWithExplicitBlock)
+    end
+  end
+)

--- a/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
+++ b/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
@@ -47,6 +47,10 @@ module RuboCop
             corrector.replace(node, block_arg_name)
           end
         end
+
+        def self.autocorrect_incompatible_with
+          [Lint::UnusedMethodArgument]
+        end
       end
     end
   end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Performance/BlockGivenWithExplicitBlock` with `Lint/UnusedMethodArgument`' do
+    source = <<~RUBY
+      def foo(&block)
+        block_given?
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(
+      cli.run(['--autocorrect', '--only', 'Performance/BlockGivenWithExplicitBlock,Lint/UnusedMethodArgument'])
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo()
+        block_given?
+      end
+    RUBY
+  end
+
   private
 
   def create_file(file_path, content)


### PR DESCRIPTION
Fixes #367.

This PR fixes an incorrect autocorrect for `Performance/BlockGivenWithExplicitBlock` when using `Lint/UnusedMethodArgument`'s autocorrection together.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
