### PR TITLE
[Fix #370] Fix an incorrect autocorrect for `Performance/RedundantMatch`

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_performance_redundant_match.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_performance_redundant_match.md
@@ -1,0 +1,1 @@
+* [#370](https://github.com/rubocop/rubocop-performance/issues/370): Fix an incorrect autocorrect for `Performance/RedundantMatch` when expressions with lower precedence than `=~` are used as an argument. ([@ymap][])

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -23,6 +23,8 @@ module RuboCop
         MSG = 'Use `=~` in places where the `MatchData` returned by `#match` will not be used.'
         RESTRICT_ON_SEND = %i[match].freeze
 
+        HIGHER_PRECEDENCE_OPERATOR_METHODS = %i[| ^ & + - * / % ** > >= < <= << >>].freeze
+
         # 'match' is a fairly generic name, so we don't flag it unless we see
         # a string or regexp literal on one side or the other
         def_node_matcher :match_call?, <<~PATTERN
@@ -47,7 +49,7 @@ module RuboCop
         private
 
         def autocorrect(corrector, node)
-          new_source = "#{node.receiver.source} =~ #{node.first_argument.source}"
+          new_source = "#{node.receiver.source} =~ #{replacement(node)}"
 
           corrector.replace(node, new_source)
         end
@@ -56,6 +58,33 @@ module RuboCop
           # Regexp#match can take a second argument, but this cop doesn't
           # register an offense in that case
           node.receiver.regexp_type? || node.first_argument.regexp_type?
+        end
+
+        def replacement(node)
+          arg = node.first_argument
+
+          if requires_parentheses?(arg)
+            "(#{arg.source})"
+          else
+            arg.source
+          end
+        end
+
+        def requires_parentheses?(arg)
+          return true if arg.if_type? && arg.ternary?
+          return true if arg.and_type? || arg.or_type? || arg.range_type?
+
+          call_like?(arg) && requires_parentheses_for_call_like?(arg)
+        end
+
+        def requires_parentheses_for_call_like?(arg)
+          return false if arg.parenthesized? || !arg.arguments?
+
+          !HIGHER_PRECEDENCE_OPERATOR_METHODS.include?(arg.method_name)
+        end
+
+        def call_like?(arg)
+          arg.call_type? || arg.yield_type? || arg.super_type?
         end
       end
     end


### PR DESCRIPTION
Fixes #370.

This PR fixes an incorrect autocorrect for `Performance/RedundantMatch` when expressions with lower precedence than `=~` are used as an argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
