### PR TITLE
Set target version for `Performance/UnfreezeString`

### DIFF
--- a/changelog/fix_target_version_for_unfreeze_string_cop.md
+++ b/changelog/fix_target_version_for_unfreeze_string_cop.md
@@ -1,0 +1,1 @@
+* [#373](https://github.com/rubocop/rubocop-performance/pull/373): Set target version for `Performance/UnfreezeString`. ([@tagliala][])

--- a/lib/rubocop/cop/performance/unfreeze_string.rb
+++ b/lib/rubocop/cop/performance/unfreeze_string.rb
@@ -26,6 +26,9 @@ module RuboCop
       #   +''
       class UnfreezeString < Base
         extend AutoCorrector
+        extend TargetRubyVersion
+
+        minimum_target_ruby_version 2.3
 
         MSG = 'Use unary plus to get an unfrozen string literal.'
         RESTRICT_ON_SEND = %i[dup new].freeze

--- a/spec/rubocop/cop/performance/unfreeze_string_spec.rb
+++ b/spec/rubocop/cop/performance/unfreeze_string_spec.rb
@@ -112,4 +112,12 @@ RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
       String.new(capacity: 100)
     RUBY
   end
+
+  context 'when Ruby <= 2.2', :ruby22 do
+    it 'does not register an offense for an empty string with `.dup`' do
+      expect_no_offenses(<<~RUBY)
+        "".dup
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
As stated in the class documentation, unary plus operator is available from Ruby 2.3.

This fix prevent RuboCop Performance to raise an offense when configured to support Ruby 2.2

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
