### PR TITLE
[Fix #374] Fix an error for `Performance/MapMethodChain`

### DIFF
--- a/changelog/fix_an_error_for_performance_map_method_chain.md
+++ b/changelog/fix_an_error_for_performance_map_method_chain.md
@@ -1,0 +1,1 @@
+* [#374](https://github.com/rubocop/rubocop-performance/issues/374): Fix an error for `Performance/MapMethodChain` when using `map` method chain without receiver. ([@koic][])

--- a/lib/rubocop/cop/performance/map_method_chain.rb
+++ b/lib/rubocop/cop/performance/map_method_chain.rb
@@ -68,6 +68,7 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/CyclomaticComplexity
         def find_begin_of_chained_map_method(node, map_args)
           return unless (chained_map_method = node.receiver)
           return if !chained_map_method.call_type? || !RESTRICT_ON_SEND.include?(chained_map_method.method_name)
@@ -77,10 +78,11 @@ module RuboCop
 
           receiver = chained_map_method.receiver
 
-          return chained_map_method unless receiver.call_type? && block_pass_with_symbol_arg?(receiver.first_argument)
+          return chained_map_method unless receiver&.call_type? && block_pass_with_symbol_arg?(receiver.first_argument)
 
           find_begin_of_chained_map_method(chained_map_method, map_args)
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/spec/rubocop/cop/performance/map_method_chain_spec.rb
+++ b/spec/rubocop/cop/performance/map_method_chain_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe RuboCop::Cop::Performance::MapMethodChain, :config do
     RUBY
   end
 
+  it 'registers an offense when using `map` method chain without receiver' do
+    expect_offense(<<~RUBY)
+      map(&:foo).map(&:bar)
+      ^^^^^^^^^^^^^^^^^^^^^ Use `map { |x| x.foo.bar }` instead of `map` method chain.
+    RUBY
+  end
+
   it 'does not register an offense when using `do_something` method chain and receiver is a method call' do
     expect_no_offenses(<<~RUBY)
       array.do_something(&:foo).do_something(&:bar)


### PR DESCRIPTION
Fixes #374.

This PR fixes an error for `Performance/MapMethodChain` when using `map` method chain without receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
