### PR TITLE
Update the doc for `Performance/Count`

### DIFF
--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -9,8 +9,7 @@ module RuboCop
       #
       # @safety
       #   This cop is unsafe because it has known compatibility issues with `ActiveRecord` and other
-      #   frameworks. ActiveRecord's `count` ignores the block that is passed to it.
-      #   `ActiveRecord` will ignore the block that is passed to `count`.
+      #   frameworks. Before Rails 5.1, `ActiveRecord` will ignore the block that is passed to `count`.
       #   Other methods, such as `select`, will convert the association to an
       #   array and then run the block on the array. A simple work around to
       #   make `count` work with a block is to call `to_a.count {...}`.


### PR DESCRIPTION
This pull request improves the doc for `Performance/Count` .

- Removed almost duplicate sentences (left the latter one only):
    > ActiveRecord's `count` ignores the block that is passed to it.

    > `ActiveRecord` will ignore the block that is passed to `count`.

- Added Rails version that fixed the described `count` method issue. Since it has been fixed in 2016, newer Rails users will not encounter this issue. 
    > Fixed ActiveRecord::Relation#count to use Ruby's Enumerable#count for counting records when a block is passed as argument instead of silently ignoring the passed block. ([Pull Request](https://github.com/rails/rails/pull/24203))
    - <https://guides.rubyonrails.org/5_1_release_notes.html>



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
