### PR TITLE
Make `Performance/StringIdentifierArgument` aware of string interpolation

### DIFF
--- a/changelog/fix_a_false_negative_for_string_identifier_argument.md
+++ b/changelog/fix_a_false_negative_for_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#386](https://github.com/rubocop/rubocop-performance/issues/386): Fix a false negative for `Performance/StringIdentifierArgument` when using string interpolation. ([@earlopain][])

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -19,9 +19,14 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
       RUBY
     end
 
-    it 'does not register an offense when using interpolated string argument' do
-      expect_no_offenses(<<~'RUBY')
-        send("do_something_#{var}")
+    it 'registers an offense when using interpolated string argument' do
+      expect_offense(<<~RUBY, method: method)
+        #{method}("do_something_\#{var}")
+        _{method} ^^^^^^^^^^^^^^^^^^^^^ Use `:"do_something_\#{var}"` instead of `"do_something_\#{var}"`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{method}(:"do_something_\#{var}")
       RUBY
     end
   end


### PR DESCRIPTION
Closes #386, see there for benchmark script. The improvement isn't quite as large as for the other cases of this cop but it's still measurable. In addition it makes the code more uniform.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
