### PR TITLE
Require RuboCop 1.30+ as runtime dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  oldest_supported_rubocop:
+    runs-on: ubuntu-latest
+    name: The oldest supported RuboCop version
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use the oldest supported RuboCop
+        run: |
+          sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" \
+              -e "/gem 'rubocop-rspec',/d" -i Gemfile
+          cat << EOF > Gemfile.local
+            gem 'rubocop', '1.30.0' # Specify the oldest supported RuboCop version
+          EOF
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: spec
+        run: bundle exec rake spec

--- a/changelog/change_require_rubocop_1_33_as_a_runtime_dependency.md
+++ b/changelog/change_require_rubocop_1_33_as_a_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#388](https://github.com/rubocop/rubocop-performance/pull/388): Require RuboCop 1.30+ as runtime dependency. ([@koic][])

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -130,7 +130,9 @@ module RuboCop
         end
 
         def rewrite_with_modifier(node, parent, new_source)
-          indent = ' ' * configured_indentation_width
+          # FIXME: `|| 2` can be removed when support is limited to RuboCop 1.44 or higher.
+          # https://github.com/rubocop/rubocop/commit/02d1e5b
+          indent = ' ' * (configured_indentation_width || 2)
           padding = "\n#{indent + leading_spaces(node)}"
           new_source.gsub!("\n", padding)
 

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 1.7.0', '< 2.0')
+  s.add_runtime_dependency('rubocop', '>= 1.30.0', '< 2.0')
   s.add_runtime_dependency('rubocop-ast', '>= 1.30.0', '< 2.0')
 end


### PR DESCRIPTION
This PR makes RuboCop Performance require RuboCop 1.30+ to fix some errors:
https://github.com/rubocop/rubocop-performance/actions/runs/6966652446/job/18957154150

It introduces CI for the oldest RuboCop version still supported, implementing a workflow for regression testing that is similar to the one found a https://github.com/rubocop/rubocop-rails/commit/c9acb7a.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
