### PR TITLE
Improve `Performance/MapCompact` to handle more safe navigation calls

### DIFF
--- a/changelog/change_improve_performance_map_compact_to.md
+++ b/changelog/change_improve_performance_map_compact_to.md
@@ -1,0 +1,1 @@
+* [#389](https://github.com/rubocop/rubocop-performance/issues/389): Improve `Performance/MapCompact` to handle more safe navigation calls. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -39,11 +39,11 @@ module RuboCop
 
         def_node_matcher :map_compact, <<~PATTERN
           {
-            (send
+            (call
               $(call _ {:map :collect}
                 (block_pass
                   (sym _))) _)
-            (send
+            (call
               (block
                 $(call _ {:map :collect})
                   (args ...) _) _)

--- a/spec/rubocop/cop/performance/map_compact_spec.rb
+++ b/spec/rubocop/cop/performance/map_compact_spec.rb
@@ -13,10 +13,21 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       RUBY
     end
 
-    it 'registers an offense when using `collection.map(&:do_something)&.compact`' do
+    it 'registers an offense when using `collection&.map(&:do_something).compact`' do
       expect_offense(<<~RUBY)
         collection&.map(&:do_something).compact
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection&.filter_map(&:do_something)
+      RUBY
+    end
+
+    it 'registers an offense when using `collection&.map(&:do_something)&.compact`' do
+      expect_offense(<<~RUBY)
+        collection&.map(&:do_something)&.compact
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -39,6 +50,17 @@ RSpec.describe RuboCop::Cop::Performance::MapCompact, :config do
       expect_offense(<<~RUBY)
         collection&.map { |item| item.do_something }.compact
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        collection&.filter_map { |item| item.do_something }
+      RUBY
+    end
+
+    it 'registers an offense when using `collection&.map { |item| item.do_something }&.compact`' do
+      expect_offense(<<~RUBY)
+        collection&.map { |item| item.do_something }&.compact
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `filter_map` instead.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-performance/issues/389.