### PR TITLE
Fix a false negative for `Performance/ReverseEach` when safe navigation is between `reverse` and `each`

### DIFF
--- a/changelog/fix_false_negative_for_reverse_each.md
+++ b/changelog/fix_false_negative_for_reverse_each.md
@@ -1,0 +1,1 @@
+* [#390](https://github.com/rubocop/rubocop-performance/issues/390): Fix a false negative for `Performance/ReverseEach` when safe navigation is between `reverse` and `each`. ([@fatkodima][])

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -27,7 +27,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[each].freeze
 
         def_node_matcher :reverse_each?, <<~MATCHER
-          (send (call _ :reverse) :each)
+          (call (call _ :reverse) :each)
         MATCHER
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach, :config do
     RUBY
   end
 
+  it 'registers an offense when each is called on reverse with safe navigation operator chain' do
+    expect_offense(<<~RUBY)
+      array&.reverse&.each { |e| puts e }
+             ^^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
+  end
+
   it 'registers an offense when each is called on reverse on a variable' do
     expect_offense(<<~RUBY)
       arr = [1, 2, 3]


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-performance/issues/390.
