### PR TITLE
[Fix #401] Make `Performance/Sum` aware of safe navigation operator

### DIFF
--- a/changelog/fix_make_performance_sum_aware_of_safe_navigation_operator.md
+++ b/changelog/fix_make_performance_sum_aware_of_safe_navigation_operator.md
@@ -1,0 +1,1 @@
+* [#401](https://github.com/rubocop/rubocop-performance/issues/401): Make `Performance/Sum` aware of safe navigation operator. ([@koic][])

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when using `array&.#{method}(10, :+)`" do
+      expect_offense(<<~RUBY, method: method)
+        array&.#{method}(10, :+)
+               ^{method}^^^^^^^^ Use `sum(10)` instead of `#{method}(10, :+)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sum(10)
+      RUBY
+    end
+
     it "registers an offense and corrects when using `array.#{method}(10) { |acc, elem| acc + elem }`" do
       expect_offense(<<~RUBY, method: method)
         array.#{method}(10) { |acc, elem| acc + elem }
@@ -21,6 +32,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
 
       expect_correction(<<~RUBY)
         array.sum(10)
+      RUBY
+    end
+
+    it "registers an offense and corrects when using `array&.#{method}(10) { |acc, elem| acc + elem }`" do
+      expect_offense(<<~RUBY, method: method)
+        array&.#{method}(10) { |acc, elem| acc + elem }
+               ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum(10)` instead of `#{method}(10) { |acc, elem| acc + elem }`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sum(10)
       RUBY
     end
 
@@ -342,6 +364,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
       RUBY
     end
 
+    it "registers an offense and corrects when using `array&.#{method} { |elem| elem ** 2 }&.sum`" do
+      expect_offense(<<~RUBY, method: method)
+        array&.%{method} { |elem| elem ** 2 }&.sum
+               ^{method}^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }&.sum`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sum { |elem| elem ** 2 }
+      RUBY
+    end
+
     it "registers an offense and corrects when using `array.#{method}(&:count).sum`" do
       expect_offense(<<~RUBY, method: method)
         array.%{method}(&:count).sum
@@ -350,6 +383,17 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
 
       expect_correction(<<~RUBY)
         array.sum(&:count)
+      RUBY
+    end
+
+    it "registers an offense and corrects when using `array&.#{method}(&:count)&.sum`" do
+      expect_offense(<<~RUBY, method: method)
+        array&.%{method}(&:count)&.sum
+               ^{method}^^^^^^^^^^^^^^ Use `sum { ... }` instead of `%{method} { ... }&.sum`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array&.sum(&:count)
       RUBY
     end
 


### PR DESCRIPTION
Fixes #401.

This PR makes `Performance/Sum` aware of safe navigation operator.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
