### PR TITLE
[Fix #384] Support optimized `String#dup` for `Performance/UnfreezeString`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" \
               -e "/gem 'rubocop-rspec',/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.30.0' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.48.1' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/new_optimized_string_dup_for_performance_unfreeze_string.md
+++ b/changelog/new_optimized_string_dup_for_performance_unfreeze_string.md
@@ -1,0 +1,1 @@
+* [#384](https://github.com/rubocop/rubocop-performance/issues/384): Support optimized `String#dup` for `Performance/UnfreezeString` when Ruby 3.3+. ([@koic][])

--- a/lib/rubocop/cop/performance/unfreeze_string.rb
+++ b/lib/rubocop/cop/performance/unfreeze_string.rb
@@ -15,8 +15,8 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   ''.dup
-      #   "something".dup
+      #   ''.dup          # when Ruby 3.2 or lower
+      #   "something".dup # when Ruby 3.2 or lower
       #   String.new
       #   String.new('')
       #   String.new('something')
@@ -45,7 +45,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless dup_string?(node) || string_new?(node)
+          return unless (dup_string?(node) && target_ruby_version <= 3.2) || string_new?(node)
 
           add_offense(node) do |corrector|
             string_value = "+#{string_value(node)}"

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('rubocop', '>= 1.30.0', '< 2.0')
+  s.add_runtime_dependency('rubocop', '>= 1.48.1', '< 2.0')
   s.add_runtime_dependency('rubocop-ast', '>= 1.30.0', '< 2.0')
 end

--- a/spec/rubocop/cop/performance/unfreeze_string_spec.rb
+++ b/spec/rubocop/cop/performance/unfreeze_string_spec.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Performance::UnfreezeString, :config do
-  it 'registers an offense and corrects for an empty string with `.dup`' do
-    expect_offense(<<~RUBY)
-      "".dup
-      ^^^^^^ Use unary plus to get an unfrozen string literal.
-    RUBY
+  context 'when Ruby <= 3.2', :ruby32 do
+    it 'registers an offense and corrects for an empty string with `.dup`' do
+      expect_offense(<<~RUBY)
+        "".dup
+        ^^^^^^ Use unary plus to get an unfrozen string literal.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      +""
-    RUBY
+      expect_correction(<<~RUBY)
+        +""
+      RUBY
+    end
+  end
+
+  context 'when Ruby >= 3.3', :ruby33 do
+    it 'does not register an offense and corrects for an empty string with `.dup`' do
+      expect_no_offenses(<<~RUBY)
+        "".dup
+      RUBY
+    end
   end
 
   it 'registers an offense and corrects for a string with `.dup`' do


### PR DESCRIPTION
Resolves #384.

This PR supports optimized `String#dup` for `Performance/UnfreezeString` when Ruby 3.3+.

To incorporate https://github.com/rubocop/rubocop/commit/d11e25f the RuboCop dependency will be updated to 1.48.1+ from 1.30.0+, but the supported runtime Ruby version will keep at Ruby 2.6+.

- https://rubygems.org/gems/rubocop/versions/1.30.0
- https://rubygems.org/gems/rubocop/versions/1.48.1

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
