### PR TITLE
Fix DoubleStartEndWith example

### DIFF
--- a/docs/modules/ROOT/pages/cops_performance.adoc
+++ b/docs/modules/ROOT/pages/cops_performance.adoc
@@ -823,10 +823,11 @@ str.end_with?(var1, var2)
 
 [source,ruby]
 ----
-# good
+# bad
 str.starts_with?("a", "b") || str.starts_with?("c")
 str.ends_with?(var1) || str.ends_with?(var2)
 
+# good
 str.starts_with?("a", "b", "c")
 str.ends_with?(var1, var2)
 ----


### PR DESCRIPTION
The example code for the DoubleStartEndWith is missing the `# bad` header for the first section here: https://docs.rubocop.org/rubocop-performance/cops_performance.html#includeactivesupportaliases-false-default

This PR adds the appropriate comments for this example.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
