### PR TITLE
[Fix #421] Fix false positives for `Performance/TimesMap`

### DIFF
--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -50,12 +50,21 @@ module RuboCop
 
         def check(node)
           times_map_call(node) do |map_or_collect, count|
+            next unless handleable_receiver?(node)
+
             add_offense(node, message: message(map_or_collect, count)) do |corrector|
               replacement = "Array.new(#{count.source}#{map_or_collect.arguments.map { |arg| ", #{arg.source}" }.join})"
 
               corrector.replace(map_or_collect, replacement)
             end
           end
+        end
+
+        def handleable_receiver?(node)
+          receiver = node.receiver.receiver
+          return true if receiver.literal? && (receiver.int_type? || receiver.float_type?)
+
+          node.receiver.dot?
         end
 
         def message(map_or_collect, count)

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -29,6 +29,48 @@ RSpec.describe RuboCop::Cop::Performance::TimesMap, :config do
         end
       end
 
+      context 'with a block with safe navigation call for integer literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            42&.times&.#{method} { |i| i.to_s }
+            ^^^^^^^^^^^^{method}^^^^^^^^^^^^^^^ Use `Array.new(42)` with a block instead of `.times.#{method}`.
+          RUBY
+        end
+      end
+
+      context 'with a block with safe navigation call for float literal' do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            4.2&.times&.#{method} { |i| i.to_s }
+            ^^^^^^^^^^^^^{method}^^^^^^^^^^^^^^^ Use `Array.new(4.2)` with a block instead of `.times.#{method}`.
+          RUBY
+        end
+      end
+
+      context 'with a block with safe navigation call for nil literal' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, method: method)
+            nil&.times&.#{method} { |i| i.to_s }
+          RUBY
+        end
+      end
+
+      context 'with a block with safe navigation call for local variable' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, method: method)
+            nullable&.times&.#{method} { |i| i.to_s }
+          RUBY
+        end
+      end
+
+      context 'with a block with safe navigation call for instance variable' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<~RUBY, method: method)
+            @nullable&.times&.#{method} { |i| i.to_s }
+          RUBY
+        end
+      end
+
       context 'for non-literal receiver' do
         it 'registers an offense' do
           expect_offense(<<~RUBY, method: method)


### PR DESCRIPTION
Fixes #421.

This PR fixes false positives for `Performance/TimesMap` with a block with safe navigation call for nil literal.

It does not have a changelog entry because it is a patch to a feature that has not been released yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
