### PR TITLE
Remove `const_get` from `StringIdentifierArgument` target

### DIFF
--- a/changelog/fix_string_identifier_argument_with_const_get.md
+++ b/changelog/fix_string_identifier_argument_with_const_get.md
@@ -1,0 +1,2 @@
+* [#427](https://github.com/rubocop/rubocop-performance/issues/425): Remove `const_get` from `StringIdentifierArgument` target. ([@okuramasafumi][])
+

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -38,7 +38,7 @@ module RuboCop
         # And `attr` may not be used because `Style/Attr` registers an offense.
         # https://github.com/rubocop/rubocop-performance/issues/278
         RESTRICT_ON_SEND = (%i[
-          class_variable_defined? const_defined? const_get const_set const_source_location
+          class_variable_defined? const_defined? const_set const_source_location
           define_method instance_method method_defined? private_class_method? private_method_defined?
           protected_method_defined? public_class_method public_instance_method public_method_defined?
           remove_class_variable remove_method undef_method class_variable_get class_variable_set


### PR DESCRIPTION
[Fix #425]
`const_get` doesn't accept symbols that are something like `:"Foo::Bar"`, and that's intended according to this issue. https://bugs.ruby-lang.org/issues/12319
Therefore, changing String to Symbol might not work as expected. As far as I know that's related to `const_get` only so we can remove it from the target of `StringIdentifierArgument`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
