### PR TITLE
Fix false negatives for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_false_negatives_for_performance_string_identifier_argument.md
+++ b/changelog/fix_false_negatives_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#428](https://github.com/rubocop/rubocop-performance/pull/428): Fix false negatives for `Performance/StringIdentifierArgument` when using multiple string arguments. ([@koic][])


### PR DESCRIPTION
This PR fixes false negatives for `Performance/StringIdentifierArgument` when using multiple string arguments.

e.g., `alias_method 'new', 'original'`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
