### PR TITLE
[Fix #425] Fix a false positive for`Performance/StringIdentifierArgument

### DIFF
--- a/changelog/fix_false_positive_for_string_identifier_argument.md
+++ b/changelog/fix_false_positive_for_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#425](https://github.com/rubocop/rubocop-performance/issues/425): Fix a false positive for `Performance/StringIdentifierArgument` when using string interpolation with methods that don't support symbols with `::` inside them. ([@earlopain][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -16,13 +16,19 @@ module RuboCop
       #   send('do_something')
       #   attr_accessor 'do_something'
       #   instance_variable_get('@ivar')
-      #   const_get("string_#{interpolation}")
+      #   respond_to?("string_#{interpolation}")
       #
       #   # good
       #   send(:do_something)
       #   attr_accessor :do_something
       #   instance_variable_get(:@ivar)
-      #   const_get(:"string_#{interpolation}")
+      #   respond_to?(:"string_#{interpolation}")
+      #
+      #   # good - these methods don't support namespaced symbols
+      #   const_get("#{module_path}::Base")
+      #   const_source_location("#{module_path}::Base")
+      #   const_defined?("#{module_path}::Base")
+      #
       #
       class StringIdentifierArgument < Base
         extend AutoCorrector
@@ -34,6 +40,8 @@ module RuboCop
           protected public public_constant module_function
         ].freeze
 
+        INTERPOLATION_IGNORE_METHODS = %i[const_get const_source_location const_defined?].freeze
+
         TWO_ARGUMENTS_METHOD = :alias_method
         MULTIPLE_ARGUMENTS_METHODS = %i[
           attr_accessor attr_reader attr_writer private private_constant
@@ -44,14 +52,14 @@ module RuboCop
         # And `attr` may not be used because `Style/Attr` registers an offense.
         # https://github.com/rubocop/rubocop-performance/issues/278
         RESTRICT_ON_SEND = (%i[
-          class_variable_defined? const_defined? const_get const_set const_source_location
+          class_variable_defined? const_set
           define_method instance_method method_defined? private_class_method? private_method_defined?
           protected_method_defined? public_class_method public_instance_method public_method_defined?
           remove_class_variable remove_method undef_method class_variable_get class_variable_set
           deprecate_constant remove_const ruby2_keywords define_singleton_method instance_variable_defined?
           instance_variable_get instance_variable_set method public_method public_send remove_instance_variable
           respond_to? send singleton_method __send__
-        ] + COMMAND_METHODS).freeze
+        ] + COMMAND_METHODS + INTERPOLATION_IGNORE_METHODS).freeze
 
         def on_send(node)
           return if COMMAND_METHODS.include?(node.method_name) && node.receiver
@@ -75,9 +83,13 @@ module RuboCop
                         [node.first_argument]
                       end
 
-          arguments.compact.filter do |argument|
-            argument.str_type? || argument.dstr_type?
-          end
+          arguments.compact.filter { |argument| string_argument_compatible?(argument, node) }
+        end
+
+        def string_argument_compatible?(argument, node)
+          return true if argument.str_type?
+
+          argument.dstr_type? && INTERPOLATION_IGNORE_METHODS.none? { |method| node.method?(method) }
         end
 
         def register_offense(argument, argument_value)

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -44,15 +44,26 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
         RUBY
       end
 
-      it 'registers an offense when using interpolated string argument' do
-        expect_offense(<<~RUBY, method: method)
-          #{method}("do_something_\#{var}")
-          _{method} ^^^^^^^^^^^^^^^^^^^^^ Use `:"do_something_\#{var}"` instead of `"do_something_\#{var}"`.
-        RUBY
+      if RuboCop::Cop::Performance::StringIdentifierArgument::INTERPOLATION_IGNORE_METHODS.include?(method)
+        it 'does not register an offense when using string interpolation for `#{method}` method' do
+          # NOTE: These methods don't support `::` when passing a symbol. const_get('A::B') is valid
+          # but const_get(:'A::B') isn't. Since interpolated arguments may contain any content these
+          # cases are not detected as an offense to prevent false positives.
+          expect_no_offenses(<<~RUBY)
+            #{method}("\#{module_name}class_name")
+          RUBY
+        end
+      else
+        it 'registers an offense when using interpolated string argument' do
+          expect_offense(<<~RUBY, method: method)
+            #{method}("do_something_\#{var}")
+            _{method} ^^^^^^^^^^^^^^^^^^^^^ Use `:"do_something_\#{var}"` instead of `"do_something_\#{var}"`.
+          RUBY
 
-        expect_correction(<<~RUBY)
-          #{method}(:"do_something_\#{var}")
-        RUBY
+          expect_correction(<<~RUBY)
+            #{method}(:"do_something_\#{var}")
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
As per my findings in https://github.com/rubocop/rubocop-performance/pull/427#issuecomment-1865914939

I updated docs with string interpolation with an explicit example. It's not quite like the initial issue report where the colon came from the variable but it should get the point across.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
