### PR TITLE
[Fix #437] Fix a false positive for `Performance/ChainArrayAllocation`

### DIFF
--- a/changelog/fix_a_false_positive_for_performance_chain_array_allocation.md
+++ b/changelog/fix_a_false_positive_for_performance_chain_array_allocation.md
@@ -1,0 +1,1 @@
+* [#437](https://github.com/rubocop/rubocop-performance/issues/437): Fix a false positive for `Performance/ChainArrayAllocation` when using `select` with block argument after `select`. ([@koic][])

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -53,4 +53,38 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
       RUBY
     end
   end
+
+  describe 'when using `select` with block argument after `select` with positional arguments' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        model.select(:foo, :bar).select { |item| item.do_something }
+      RUBY
+    end
+  end
+
+  describe 'when using `select` with block argument after `select` with block argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        model.select { |item| item.foo }.select { |item| item.bar }
+                                        ^^^^^^^ Use unchained `select` and `select!` (followed by `return array` if required) instead of chaining `select...select`.
+      RUBY
+    end
+  end
+
+  describe 'when using `select` with block argument after `select` with numbered block argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        model.select { _1.foo }.select { |item| item.bar }
+                               ^^^^^^^ Use unchained `select` and `select!` (followed by `return array` if required) instead of chaining `select...select`.
+      RUBY
+    end
+  end
+
+  describe 'when using `select` with positional arguments after `select`' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        model.select(:foo, :bar).select(:baz, :qux)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #437.

This PR fixes a false positive for `Performance/ChainArrayAllocation` when using `select` with block argument after `select`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
