### PR TITLE
[Fix #240] Disable `Performance/Casecmp` cop

### DIFF
--- a/changelog/change_disalbe_performance_casecmp_by_default.md
+++ b/changelog/change_disalbe_performance_casecmp_by_default.md
@@ -1,0 +1,1 @@
+* [#240](https://github.com/rubocop/rubocop-performance/issues/240): Disable `Performance/Casecmp` cop by default. ([@parkerfinch][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -55,9 +55,10 @@ Performance/Casecmp:
   Description: >-
              Use `casecmp` rather than `downcase ==`, `upcase ==`, `== downcase`, or `== upcase`..
   Reference: 'https://github.com/fastruby/fast-ruby#stringcasecmp-vs--stringcasecmp-vs-stringdowncase---code'
-  Enabled: true
+  Enabled: false
   Safe: false
   VersionAdded: '0.36'
+  VersionChanged: '<<next>>'
 
 Performance/ChainArrayAllocation:
   Description: >-

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -6,6 +6,12 @@ module RuboCop
       # Identifies places where a case-insensitive string comparison
       # can better be implemented using `casecmp`.
       #
+      # This cop is disabled by default because `String#casecmp` only works with
+      # ASCII characters. See https://github.com/rubocop/rubocop/issues/9753.
+      #
+      # If you are working only with ASCII characters, then this cop can be
+      # safely enabled.
+      #
       # @safety
       #   This cop is unsafe because `String#casecmp` and `String#casecmp?` behave
       #   differently when using Non-ASCII characters.


### PR DESCRIPTION
This cop suggests an incorrect fix when code involves non-ASCII characters. Disabling it by default makes this risky behavior opt-in rather than opt-out.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
