### PR TITLE
[Fix #444] Fix an incorrect autocorrect for `Performance/BlockGivenWi…

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_performance_block_given_with_explicit_block.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_performance_block_given_with_explicit_block.md
@@ -1,0 +1,1 @@
+* [#444](https://github.com/rubocop/rubocop-performance/issues/444): Fix an incorrect autocorrect for `Performance/BlockGivenWithExplicitBlock` when using `Naming/BlockForwarding`'s autocorrection together. ([@a-lavis][])

--- a/lib/rubocop-performance.rb
+++ b/lib/rubocop-performance.rb
@@ -10,10 +10,16 @@ RuboCop::Performance::Inject.defaults!
 
 require_relative 'rubocop/cop/performance_cops'
 
-RuboCop::Cop::Lint::UnusedMethodArgument.singleton_class.prepend(
-  Module.new do
-    def autocorrect_incompatible_with
-      super.push(RuboCop::Cop::Performance::BlockGivenWithExplicitBlock)
-    end
+autocorrect_incompatible_with_block_given_with_explicit_block = Module.new do
+  def autocorrect_incompatible_with
+    super.push(RuboCop::Cop::Performance::BlockGivenWithExplicitBlock)
   end
+end
+
+RuboCop::Cop::Lint::UnusedMethodArgument.singleton_class.prepend(
+  autocorrect_incompatible_with_block_given_with_explicit_block
+)
+
+RuboCop::Cop::Naming::BlockForwarding.singleton_class.prepend(
+  autocorrect_incompatible_with_block_given_with_explicit_block
 )

--- a/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
+++ b/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
@@ -49,7 +49,7 @@ module RuboCop
         end
 
         def self.autocorrect_incompatible_with
-          [Lint::UnusedMethodArgument]
+          [Lint::UnusedMethodArgument, Naming::BlockForwarding]
         end
       end
     end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
     RUBY
   end
 
+  it 'corrects `Performance/BlockGivenWithExplicitBlock` with `Naming/BlockForwarding`' do
+    source = <<~RUBY
+      def foo(&block)
+        block_given?
+        bar(&block)
+      end
+    RUBY
+    create_file('example.rb', source)
+    expect(
+      cli.run(['--autocorrect', '--only', 'Performance/BlockGivenWithExplicitBlock,Naming/BlockForwarding'])
+    ).to eq(0)
+    expect(File.read('example.rb')).to eq(<<~RUBY)
+      def foo(&block)
+        block
+        bar(&block)
+      end
+    RUBY
+  end
+
   private
 
   def create_file(file_path, content)


### PR DESCRIPTION
…thExplicitBlock`

Fixes #444.

This PR fixes an incorrect autocorrect for `Performance/BlockGivenWithExplicitBlock` when using `Naming/BlockForwarding`'s autocorrection together.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
