### PR TITLE
[Fix #448] Fix a false positive for `Performance/RedundantBlockCall`

### DIFF
--- a/changelog/fix_false_positive_for_performance_redundant_block_call.md
+++ b/changelog/fix_false_positive_for_performance_redundant_block_call.md
@@ -1,0 +1,1 @@
+* [#448](https://github.com/rubocop/rubocop-performance/issues/448): Fix a false positive for `Performance/RedundantBlockCall` when using `block.call` with block argument. ([@koic][])

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -49,6 +49,8 @@ module RuboCop
             next unless body
 
             calls_to_report(argname, body).each do |blockcall|
+              next if blockcall.block_literal?
+
               add_offense(blockcall, message: format(MSG, argname: argname)) do |corrector|
                 autocorrect(corrector, blockcall)
               end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall, :config do
     RUBY
   end
 
+  it 'accepts when using `block.call` with block argument' do
+    expect_no_offenses(<<~RUBY)
+      def method(&block)
+        block.call { do_something }
+      end
+    RUBY
+  end
+
+  it 'accepts when using `block.call` with numbered block argument' do
+    expect_no_offenses(<<~RUBY)
+      def method(&block)
+        block.call { _1.do_something }
+      end
+    RUBY
+  end
+
   it 'accepts another block being passed along with other args' do
     expect_no_offenses(<<~RUBY)
       def method(&block)


### PR DESCRIPTION
Fixes #448.

This PR fixes a false positive for `Performance/RedundantBlockCall` when using `block.call` with block argument.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
