### PR TITLE
Improve explanation for safety of `MapCompact` autocorrection in docs

### DIFF
--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -8,8 +8,9 @@ module RuboCop
       # This cop identifies places where `map { ... }.compact` can be replaced by `filter_map`.
       #
       # @safety
-      #   This cop's autocorrection is unsafe because `map { ... }.compact` that is not
-      #   compatible with `filter_map`.
+      #   This cop's autocorrection is unsafe because `map { ... }.compact` might yield
+      #   different results than `filter_map`. As illustrated in the example, `filter_map`
+      #   also filters out falsy values, while `compact` only gets rid of `nil`.
       #
       # [source,ruby]
       # ----


### PR DESCRIPTION
When I first read about the [`Performance/MapCompact`](https://docs.rubocop.org/rubocop-performance/cops_performance.html#safety-11) cop, I didn't understand the following sentence at first glance:

> This cop's autocorrection is unsafe because `map { ... }.compact` that is not compatible with `filter_map`.

- The `that` in this sentence is confusing me grammatically-wise.
- And this explanation did not hint me to _why_ it's not safe. In hindsight, I don't know why I haven't just looked at the example one line above to see the actual difference. But maybe, for other users, it might be as well beneficial to improve the wording and refer to the given example to clearly point out that falsy values are filtered out by `filter_map` as well (see the [Ruby docs](https://ruby-doc.org/3.1.4/Enumerable.html#method-i-filter_map)). Compare that with [`compact`](https://apidock.com/ruby/v2_5_5/Array/compact), which only gets rid of `nil` values.

This fixes #280. The issue was already closed, however, it "fixes" it in the sense that the underlying confusion should be mitigated by a better wording in the docs.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists). -> ⚠ I've included the related issue it in the PR message as well as in the changelog entry. I forgot to add it to the commit message itself, hope that's ok.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together. -> ⚠ The first two commits of this PR could be squashed together. As I'm not rebasing very often, I'd have to look up how that works. If these two commits (that probably get squashed together into master anyways), do not impose a serious problem, maybe I can keep them as they are?
* [ ] Added tests. -> ⚠ Not needed as this is just a small documentation change
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

🛑 As a sidenote: Note that in the last checklist item, you're linking to the contribution guide of rubocop (via the _changelog entry format_ link), not that of [this repo](https://github.com/rubocop/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).