### PR TITLE
Restore skipped specs for Prism

### DIFF
--- a/spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb
+++ b/spec/rubocop/cop/performance/collection_literal_in_loop_spec.rb
@@ -144,9 +144,7 @@ RSpec.describe RuboCop::Cop::Performance::CollectionLiteralInLoop, :config do
       RUBY
     end
 
-    # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-    # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-    it 'registers an offense when the method is called with no receiver', broken_on: :prism do
+    it 'registers an offense when the method is called with no receiver' do
       expect_offense(<<~RUBY)
         all? do |e|
           [1, 2, 3].include?(e)

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
-  # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-  # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-  context 'when receiver is implicit', broken_on: :prism do
+  context 'when receiver is implicit' do
     it "doesn't autocorrect" do
       new_source = autocorrect_source('merge!(foo: 1, bar: 2)')
       expect(new_source).to eq('merge!(foo: 1, bar: 2)')

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -27,9 +27,7 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
         RUBY
       end
     else
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-      # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-      it "registers an offense when using string argument for `#{method}` method", broken_on: :prism do
+      it "registers an offense when using string argument for `#{method}` method" do
         expect_offense(<<~RUBY, method: method)
           #{method}('do_something')
           _{method} ^^^^^^^^^^^^^^ Use `:do_something` instead of `'do_something'`.
@@ -40,18 +38,14 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
         RUBY
       end
 
-      # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-      # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-      it "does not register an offense when using symbol argument for `#{method}` method", broken_on: :prism do
+      it "does not register an offense when using symbol argument for `#{method}` method" do
         expect_no_offenses(<<~RUBY)
           #{method}(:do_something)
         RUBY
       end
 
       if described_class::INTERPOLATION_IGNORE_METHODS.include?(method)
-        # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-        # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-        it 'does not register an offense when using string interpolation for `#{method}` method', broken_on: :prism do
+        it 'does not register an offense when using string interpolation for `#{method}` method' do
           # NOTE: These methods don't support `::` when passing a symbol. const_get('A::B') is valid
           # but const_get(:'A::B') isn't. Since interpolated arguments may contain any content these
           # cases are not detected as an offense to prevent false positives.
@@ -60,9 +54,7 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
           RUBY
         end
       else
-        # FIXME: `undefined method `[]' for nil` occurs Prism 0.24.0. It has been resolved in
-        # the development line. This will be resolved in Prism > 0.24.0 and higher releases.
-        it 'registers an offense when using interpolated string argument', broken_on: :prism do
+        it 'registers an offense when using interpolated string argument' do
           expect_offense(<<~RUBY, method: method)
             #{method}("do_something_\#{var}")
             _{method} ^^^^^^^^^^^^^^^^^^^^^ Use `:"do_something_\#{var}"` instead of `"do_something_\#{var}"`.


### PR DESCRIPTION
This PR restores skipped specs for Prism. They have already been resolved in Prism, so they can be tested.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
