### PR TITLE
Fix error for `Performance/RedundantEqualityComparisonBlock` when block is empty

### DIFF
--- a/changelog/fix_error_for_redundant_equality_comparison_block.md
+++ b/changelog/fix_error_for_redundant_equality_comparison_block.md
@@ -1,0 +1,1 @@
+* [#452](https://github.com/rubocop/rubocop-performance/pull/452): Fix an error for `Performance/RedundantEqualityComparisonBlock` when the block is empty. ([@earlopain][])

--- a/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
+++ b/lib/rubocop/cop/performance/redundant_equality_comparison_block.rb
@@ -64,7 +64,7 @@ module RuboCop
           return unless one_block_argument?(node.arguments)
 
           block_argument = node.first_argument
-          block_body = node.body
+          return unless (block_body = node.body)
           return unless use_equality_comparison_block?(block_body)
           return if same_block_argument_and_is_a_argument?(block_body, block_argument)
           return unless (new_argument = new_argument(block_argument, block_body))

--- a/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_equality_comparison_block_spec.rb
@@ -181,4 +181,16 @@ RSpec.describe RuboCop::Cop::Performance::RedundantEqualityComparisonBlock, :con
       items.any? { |item| do_something[0..item] == item }
     RUBY
   end
+
+  it 'does not register an offense when the block is empty' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { |item| }
+    RUBY
+  end
+
+  it 'does not register an offense when the block takes no argument' do
+    expect_no_offenses(<<~RUBY)
+      items.any? { }
+    RUBY
+  end
 end


### PR DESCRIPTION

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
