### PR TITLE
Fix readme CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RuboCop Performance
 
 [![Gem Version](https://badge.fury.io/rb/rubocop-performance.svg)](https://badge.fury.io/rb/rubocop-performance)
-[![CircleCI](https://circleci.com/gh/rubocop/rubocop-performance.svg?style=svg)](https://circleci.com/gh/rubocop/rubocop-performance)
+[![CI](https://github.com/rubocop/rubocop-performance/actions/workflows/test.yml/badge.svg)](https://github.com/rubocop/rubocop-performance/actions/workflows/test.yml)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg?sanitize=true)](https://discord.gg/wJjWvGRDmm)
 
 Performance optimization analysis for your projects, as an extension to [RuboCop](https://github.com/rubocop/rubocop).


### PR DESCRIPTION
There's no CircleCI here, it's all GitHub actions: #398

![image](https://github.com/rubocop/rubocop-performance/assets/14981592/eb0cb760-a58b-4896-9b44-1bb2acc1707c)
