### PR TITLE
Don't use deprecated `Cop.registry` in specs

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe 'RuboCop Performance Project', type: :feature do
       end
 
       let(:existing_cop_names) do
-        RuboCop::Cop::Cop.registry.without_department(:Test).without_department(:Test2).cops.to_set(&:cop_name)
+        RuboCop::Cop::Registry.global.reject { |cop| cop.cop_name.start_with?('Test/') }.to_set(&:cop_name)
       end
 
       let(:legacy_cop_names) do


### PR DESCRIPTION
Also update cop filtering for https://github.com/rubocop/rubocop/pull/13123