### PR TITLE
Fix a random test failure for `Performance/Sum`

### DIFF
--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -7,10 +7,16 @@ RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:
 
   include_context 'mock console output'
 
-  before do
+  # Restore injected config as well
+  around do |ex|
+    previous_config = RuboCop::ConfigLoader.default_configuration
+
     RuboCop::ConfigLoader.default_configuration = nil
     RuboCop::ConfigLoader.default_configuration.for_all_cops['SuggestExtensions'] = false
     RuboCop::ConfigLoader.default_configuration.for_all_cops['NewCops'] = 'disable'
+    ex.call
+  ensure
+    RuboCop::ConfigLoader.default_configuration = previous_config
   end
 
   it 'corrects `Performance/ConstantRegexp` with `Performance/RegexpMatch`' do

--- a/spec/rubocop/cop/performance/sum_spec.rb
+++ b/spec/rubocop/cop/performance/sum_spec.rb
@@ -271,10 +271,6 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
               ^{method}^^^^^ Use `sum` instead of `#{method}(&:+)`, unless calling `#{method}(&:+)` on an empty array.
       RUBY
 
-      # FIXME: The following failures in JRuby need to be fixed:
-      # https://github.com/rubocop/rubocop-performance/actions/runs/7013730884/job/19080337215
-      skip('Unexpected JRuby autocorrection test failure needs to be fixed.') if RUBY_ENGINE == 'jruby'
-
       expect_correction(<<~RUBY)
         array.sum
       RUBY
@@ -285,10 +281,6 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
         array.#{method}(:+)
               ^{method}^^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
       RUBY
-
-      # FIXME: The following failures in JRuby need to be fixed:
-      # https://github.com/rubocop/rubocop-performance/actions/runs/7013730884/job/19080337215
-      skip('Unexpected JRuby autocorrection test failure needs to be fixed.') if RUBY_ENGINE == 'jruby'
 
       expect_correction(<<~RUBY)
         array.sum
@@ -301,10 +293,6 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
               ^{method}^^^ Use `sum` instead of `#{method}(:+)`, unless calling `#{method}(:+)` on an empty array.
       RUBY
 
-      # FIXME: The following failures in JRuby need to be fixed:
-      # https://github.com/rubocop/rubocop-performance/actions/runs/7013730884/job/19080337215
-      skip('Unexpected JRuby autocorrection test failure needs to be fixed.') if RUBY_ENGINE == 'jruby'
-
       expect_correction(<<~RUBY)
         array.sum
       RUBY
@@ -315,10 +303,6 @@ RSpec.describe RuboCop::Cop::Performance::Sum, :config do
         [1, 2, 3].#{method}(:+)
                   ^{method}^^^^ Use `sum` instead of `#{method}(:+)`.
       RUBY
-
-      # FIXME: The following failures in JRuby need to be fixed:
-      # https://github.com/rubocop/rubocop-performance/actions/runs/7013730884/job/19080337215
-      skip('Unexpected JRuby autocorrection test failure needs to be fixed.') if RUBY_ENGINE == 'jruby'
 
       expect_correction(<<~RUBY)
         [1, 2, 3].sum


### PR DESCRIPTION
The skipped tests fail with the following command: `bundle exec rspec ./spec/rubocop/cli/autocorrect_spec.rb[1:1] ./spec/rubocop/cop/performance/sum_spec.rb[1:13] --seed 26805` (or maybe not, there is something extra going on I don't understand)

This is fine to do in the rubocop main repository but here we inject additional config values that are not restored.

There are some things going on that I don't entirely understand:
* Why only failures in this one file
* Why did koic not manage to reproduce with the exact same seed
* Why did the failures seemingly disappear and reappear without any changes to the code

But regardless, this is more correct. Removing the JRuby skips is a bit of a guess on my side but I don't see what else should prevent them from passing. Let's see how it goes.

Bit of extra context starting at https://github.com/rubocop/rubocop-performance/pull/398#issuecomment-2301743107
