### PR TITLE
Remove RuboCop < 1.44 workaround

### DIFF
--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -130,9 +130,7 @@ module RuboCop
         end
 
         def rewrite_with_modifier(node, parent, new_source)
-          # FIXME: `|| 2` can be removed when support is limited to RuboCop 1.44 or higher.
-          # https://github.com/rubocop/rubocop/commit/02d1e5b
-          indent = ' ' * (configured_indentation_width || 2)
+          indent = ' ' * configured_indentation_width
           padding = "\n#{indent + leading_spaces(node)}"
           new_source.gsub!("\n", padding)
 


### PR DESCRIPTION
Minimum version is currently 1.48

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
