### PR TITLE
Fix [#407] Make `Performance/DoubleStartEndWith` aware of safe navigation

### DIFF
--- a/changelog/change_make_double_start_end_aware_safe_navigation.md
+++ b/changelog/change_make_double_start_end_aware_safe_navigation.md
@@ -1,0 +1,1 @@
+* [#407](https://github.com/rubocop/rubocop-performance/issues/407): Make `Performance/DoubleStartEndWith` aware of safe navigation. ([@earlopain][])


### PR DESCRIPTION
Fixes #407.

In case of inconsistent safe navigation, it keeps the dot from the first receiver.

This shouldn't change anything:
Depending on the order, it was either not needed or it will continue raising.

`Lint/SafeNavigationConsistency` takes care of this anyways


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
