### PR TITLE
[Fix #385] Disable `Performance/BlockGivenWithExplicitBlock` by default

### DIFF
--- a/changelog/change_disable_block_given.md
+++ b/changelog/change_disable_block_given.md
@@ -1,0 +1,1 @@
+* [#385](https://github.com/rubocop/rubocop-performance/issues/385): Disable `Performance/BlockGivenWithExplicitBlock` by default. ([@earlopain][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -32,8 +32,11 @@ Performance/BindCall:
 
 Performance/BlockGivenWithExplicitBlock:
   Description: 'Check block argument explicitly instead of using `block_given?`.'
-  Enabled: pending
+  # This cop was created due to a mistake in microbenchmark.
+  # https://github.com/rubocop/rubocop-performance/issues/385
+  Enabled: false
   VersionAdded: '1.9'
+  VersionChanged: <<next>>
 
 Performance/Caller:
   Description: >-

--- a/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
+++ b/lib/rubocop/cop/performance/block_given_with_explicit_block.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Identifies unnecessary use of a `block_given?` where explicit check
       # of block argument would suffice.
       #
+      # NOTE: This cop produces code with significantly worse performance when a
+      # block is being passed to the method and as such should not be enabled.
+      #
       # @example
       #   # bad
       #   def method(&block)


### PR DESCRIPTION
See linked issue for benchmark details.

I tested with YJIT and its even worse:
```
ruby 3.4.0dev (2024-09-05T09:43:46Z master 63cbe3f6ac) +YJIT [x86_64-linux]
Warming up --------------------------------------
               block     1.635M i/100ms
      block w/ block   285.930k i/100ms
        block_given?     1.867M i/100ms
block_given? w/ block
                         1.497M i/100ms
Calculating -------------------------------------
               block     22.611M (±12.7%) i/s   (44.23 ns/i) -    111.180M in   5.033721s
      block w/ block      3.034M (± 8.5%) i/s  (329.59 ns/i) -     15.154M in   5.032609s
        block_given?     24.935M (±10.7%) i/s   (40.10 ns/i) -    123.254M in   5.002983s
block_given? w/ block
                         23.007M (±14.7%) i/s   (43.47 ns/i) -    113.782M in   5.058213s

Comparison:
        block_given?: 24935388.3 i/s
block_given? w/ block: 23006920.5 i/s - same-ish: difference falls within error
               block: 22610939.8 i/s - same-ish: difference falls within error
      block w/ block:  3034047.2 i/s - 8.22x  slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
