### PR TITLE
Caller: use lonely operator to safely call `#first`

### DIFF
--- a/changelog/fix_caller_use_lonely_operator_to_safely.md
+++ b/changelog/fix_caller_use_lonely_operator_to_safely.md
@@ -1,0 +1,1 @@
+* [#476](https://github.com/rubocop/rubocop-performance/pull/476): Caller: use lonely operator to safely call `#first`. ([@chastell][])

--- a/lib/rubocop/cop/performance/caller.rb
+++ b/lib/rubocop/cop/performance/caller.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Performance
-      # Identifies places where `caller[n]` can be replaced by `caller(n..n).first`.
+      # Identifies places where `caller[n]` can be replaced by `caller(n..n)&.first`.
       #
       # @example
       #   # bad
@@ -13,9 +13,9 @@ module RuboCop
       #   caller_locations.first
       #
       #   # good
-      #   caller(2..2).first
+      #   caller(2..2)&.first
       #   caller(1..1).first
-      #   caller_locations(2..2).first
+      #   caller_locations(2..2)&.first
       #   caller_locations(1..1).first
       class Caller < Base
         extend AutoCorrector
@@ -48,7 +48,7 @@ module RuboCop
             n += m
           end
 
-          preferred_method = "#{method_name}(#{n}..#{n}).first"
+          preferred_method = "#{method_name}(#{n}..#{n})&.first"
 
           message = format(MSG, preferred_method: preferred_method, current_method: node.source)
           add_offense(node, message: message) do |corrector|

--- a/spec/rubocop/cop/performance/caller_spec.rb
+++ b/spec/rubocop/cop/performance/caller_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller.first).to eq(caller(1..1).first)
     expect_offense(<<~RUBY)
       caller.first
-      ^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller.first`.
+      ^^^^^^^^^^^^ Use `caller(1..1)&.first` instead of `caller.first`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(1..1).first
+      caller(1..1)&.first
     RUBY
   end
 
@@ -29,11 +29,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller(1).first).to eq(caller(1..1).first)
     expect_offense(<<~RUBY)
       caller(1).first
-      ^^^^^^^^^^^^^^^ Use `caller(1..1).first` instead of `caller(1).first`.
+      ^^^^^^^^^^^^^^^ Use `caller(1..1)&.first` instead of `caller(1).first`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(1..1).first
+      caller(1..1)&.first
     RUBY
   end
 
@@ -41,11 +41,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller(2).first).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller(2).first
-      ^^^^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller(2).first`.
+      ^^^^^^^^^^^^^^^ Use `caller(2..2)&.first` instead of `caller(2).first`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(2..2).first
+      caller(2..2)&.first
     RUBY
   end
 
@@ -53,11 +53,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller[1]).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller[1]
-      ^^^^^^^^^ Use `caller(2..2).first` instead of `caller[1]`.
+      ^^^^^^^^^ Use `caller(2..2)&.first` instead of `caller[1]`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(2..2).first
+      caller(2..2)&.first
     RUBY
   end
 
@@ -65,11 +65,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller(1)[1]).to eq(caller(2..2).first)
     expect_offense(<<~RUBY)
       caller(1)[1]
-      ^^^^^^^^^^^^ Use `caller(2..2).first` instead of `caller(1)[1]`.
+      ^^^^^^^^^^^^ Use `caller(2..2)&.first` instead of `caller(1)[1]`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(2..2).first
+      caller(2..2)&.first
     RUBY
   end
 
@@ -77,11 +77,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller(2)[1]).to eq(caller(3..3).first)
     expect_offense(<<~RUBY)
       caller(2)[1]
-      ^^^^^^^^^^^^ Use `caller(3..3).first` instead of `caller(2)[1]`.
+      ^^^^^^^^^^^^ Use `caller(3..3)&.first` instead of `caller(2)[1]`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller(3..3).first
+      caller(3..3)&.first
     RUBY
   end
 
@@ -89,11 +89,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller_locations.first.to_s).to eq(caller_locations(1..1).first.to_s)
     expect_offense(<<~RUBY)
       caller_locations.first
-      ^^^^^^^^^^^^^^^^^^^^^^ Use `caller_locations(1..1).first` instead of `caller_locations.first`.
+      ^^^^^^^^^^^^^^^^^^^^^^ Use `caller_locations(1..1)&.first` instead of `caller_locations.first`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller_locations(1..1).first
+      caller_locations(1..1)&.first
     RUBY
   end
 
@@ -101,11 +101,11 @@ RSpec.describe RuboCop::Cop::Performance::Caller, :config do
     expect(caller_locations[1].to_s).to eq(caller_locations(2..2).first.to_s)
     expect_offense(<<~RUBY)
       caller_locations[1]
-      ^^^^^^^^^^^^^^^^^^^ Use `caller_locations(2..2).first` instead of `caller_locations[1]`.
+      ^^^^^^^^^^^^^^^^^^^ Use `caller_locations(2..2)&.first` instead of `caller_locations[1]`.
     RUBY
 
     expect_correction(<<~RUBY)
-      caller_locations(2..2).first
+      caller_locations(2..2)&.first
     RUBY
   end
 end


### PR DESCRIPTION
The Caller cop currently replaces `caller[42]` with `caller(43..43).first`.

If the caller stack is short, the former returns `nil` while the latter raises a `NoMethodError` (_undefined method `first' for nil_).

This PR fixes this by using the lonely operator (`&.`) to call `#first` only if the result is non-`nil`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
