### PR TITLE
Fix `Performance/RedundantStringChars` cop error in case of implicit receiver

### DIFF
--- a/changelog/fix_performance_redundant_string_chars_cop_error_in_case_of_implicit_receiver.md
+++ b/changelog/fix_performance_redundant_string_chars_cop_error_in_case_of_implicit_receiver.md
@@ -1,0 +1,1 @@
+* [#478](https://github.com/rubocop/rubocop-performance/pull/478): Fix `Performance/RedundantStringChars` cop error in case of implicit receiver. ([@viralpraxis][])

--- a/lib/rubocop/cop/performance/redundant_string_chars.rb
+++ b/lib/rubocop/cop/performance/redundant_string_chars.rb
@@ -48,7 +48,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[[] slice first last take length size empty?].freeze
 
         def_node_matcher :redundant_chars_call?, <<~PATTERN
-          (send $(send _ :chars) $_ $...)
+          (send $(send !nil? :chars) $_ $...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
@@ -139,4 +139,10 @@ RSpec.describe RuboCop::Cop::Performance::RedundantStringChars, :config do
       str.chars.max
     RUBY
   end
+
+  it 'does not register an offense with implicit receiver' do
+    expect_no_offenses(<<~RUBY)
+      chars.size
+    RUBY
+  end
 end


### PR DESCRIPTION
```console
echo 'chars.size' | be rubocop --only Performance/RedundantStringChars --stdin bug.rb -d

Inspecting 1 file
Scanning bug.rb
An error occurred while Performance/RedundantStringChars cop was inspecting bug.rb:1:0.
undefined method `begin_pos' for nil
lib/rubocop/cop/performance/redundant_string_chars.rb:76:in `correction_range'
lib/rubocop/cop/performance/redundant_string_chars.rb:62:in `block in on_send'
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
