### PR TITLE
Fix `Performance/Squeeze` cop error on frozen AST string node value

### DIFF
--- a/changelog/fix_performance_squeeze_cop_error_on_frozen_ast_string_node_value.md
+++ b/changelog/fix_performance_squeeze_cop_error_on_frozen_ast_string_node_value.md
@@ -1,0 +1,1 @@
+* [#480](https://github.com/rubocop/rubocop-performance/pull/480): Fix `Performance/Squeeze` cop error on frozen AST string node value. ([@viralpraxis][])

--- a/lib/rubocop/cop/performance/squeeze.rb
+++ b/lib/rubocop/cop/performance/squeeze.rb
@@ -46,7 +46,11 @@ module RuboCop
             message = format(MSG, current: bad_method, prefer: good_method)
 
             add_offense(node.loc.selector, message: message) do |corrector|
-              string_literal = to_string_literal(replace_str)
+              # FIXME: When requiring only RuboCop 1.70.0 and above,
+              # `dup` in `replace_str.dup` becomes unnecessary, as
+              # frozen strings are handled in the `to_string_literal`
+              # implementation. Please remove it.
+              string_literal = to_string_literal(replace_str.dup)
               new_code = "#{receiver.source}#{node.loc.dot.source}#{good_method}(#{string_literal})"
 
               corrector.replace(node, new_code)

--- a/spec/rubocop/cop/performance/squeeze_spec.rb
+++ b/spec/rubocop/cop/performance/squeeze_spec.rb
@@ -51,4 +51,15 @@ RSpec.describe RuboCop::Cop::Performance::Squeeze, :config do
       str.gsub(/a+/, 'b')
     RUBY
   end
+
+  it 'registers an offense when AST string literal might be frozen' do
+    expect_offense(<<~'RUBY')
+      str.gsub(/\n+/, ?\n)
+          ^^^^ Use `squeeze` instead of `gsub`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      str.squeeze("\n")
+    RUBY
+  end
 end


### PR DESCRIPTION
Since sometimes AST string nodes might have their values frozen, we should call `dup` explicitly to make sure `to_string_literal` (which does not work with frozen strings) does not raise. Maybe we should also apply a patch on RuboCop's core side to fix the `to_string_literal` itself (it now uses `force_encoding` on its argument).

See [1] and [2] for details.

[1] https://github.com/ruby/prism/issues/3309
[2] https://github.com/rubocop/rubocop-ast/issues/342

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

