### PR TITLE
Add missing `RESTRICT_ON_SEND` for two cops

### DIFF
--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -45,6 +45,8 @@ module RuboCop
 
         RETURNS_NEW_ARRAY = (ALWAYS_RETURNS_NEW_ARRAY + RETURNS_NEW_ARRAY_WHEN_NO_BLOCK).freeze
 
+        RESTRICT_ON_SEND = RETURNS_NEW_ARRAY
+
         MSG = 'Use unchained `%<method>s` and `%<second_method>s!` ' \
               '(followed by `return array` if required) instead of chaining ' \
               '`%<method>s...%<second_method>s`.'

--- a/lib/rubocop/cop/performance/collection_literal_in_loop.rb
+++ b/lib/rubocop/cop/performance/collection_literal_in_loop.rb
@@ -65,6 +65,8 @@ module RuboCop
 
         HASH_METHODS = (ENUMERABLE_METHOD_NAMES | NONMUTATING_HASH_METHODS).to_set.freeze
 
+        RESTRICT_ON_SEND = ARRAY_METHODS + HASH_METHODS
+
         def_node_matcher :kernel_loop?, <<~PATTERN
           (block
             (send {nil? (const nil? :Kernel)} :loop)


### PR DESCRIPTION
For these, it is known on what methods they will operate on

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
