### PR TITLE
Change `Performance/CollectionLiteralInLoop` to not register offenses for `Array#include?` that are optimized directly in Ruby.

### DIFF
--- a/changelog/change_collection_literal_include_ruby34.md
+++ b/changelog/change_collection_literal_include_ruby34.md
@@ -1,0 +1,1 @@
+* [#482](https://github.com/rubocop/rubocop-performance/issues/482): Change `Performance/CollectionLiteralInLoop` to not register offenses for `Array#include?` that are optimized directly in Ruby. ([@earlopain][])


### PR DESCRIPTION
Fix #482. Since `include?` on arrays are the only instances I ever run across this cop, I think it makes sense to add special handling for this.

On Ruby 3.4 this does no array allocations:
```rb
require "memory_profiler"

class Foo
  def bar
    Bar.new
  end
end

class Bar
  def baz
  end
end

foo = Foo.new
report = MemoryProfiler.report do
  [1,2].include?(foo.bar.baz)
end.pretty_print
```

Also, this code is simply slower on Ruby 3.4:

```rb
require "benchmark/ips"

local = [301, 302]
val = 301
Benchmark.ips do |x|
  x.report('local') do
    local.include?(val)
  end

  x.report('literal') do
    [301, 302].include?(val)
  end
  x.compare!
end
```

```
$ ruby test.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
               local     1.822M i/100ms
             literal     2.296M i/100ms
Calculating -------------------------------------
               local     18.235M (± 1.6%) i/s   (54.84 ns/i) -     92.906M in   5.096277s
             literal     22.807M (± 1.5%) i/s   (43.85 ns/i) -    114.789M in   5.034289s

Comparison:
             literal: 22806932.0 i/s
               local: 18235340.7 i/s - 1.25x  slower
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
