### PR TITLE
Use node groups in node patterns to replace unions of types

### DIFF
--- a/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
+++ b/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
@@ -44,8 +44,8 @@ module RuboCop
 
         def_node_matcher :endless_range?, <<~PATTERN
           {
-            ({irange erange} nil? (int positive?))
-            ({irange erange} (int positive?) nil?)
+            (range nil? (int positive?))
+            (range (int positive?) nil?)
           }
         PATTERN
 

--- a/lib/rubocop/cop/performance/range_include.rb
+++ b/lib/rubocop/cop/performance/range_include.rb
@@ -38,7 +38,7 @@ module RuboCop
         # (We don't even catch it if the Range is in double parens)
 
         def_node_matcher :range_include, <<~PATTERN
-          (call {irange erange (begin {irange erange})} ${:include? :member?} ...)
+          (call {range (begin range)} ${:include? :member?} ...)
         PATTERN
 
         def on_send(node)


### PR DESCRIPTION
`rubocop-ast` defines some node groups (https://github.com/rubocop/rubocop-ast/blob/85bfe84/lib/rubocop/ast/node.rb#L89-L116) that can be used in place of a union of node types.