### PR TITLE
[Fix #492] Fix false positives for `Performance/StringIdentifierArgument`

### DIFF
--- a/changelog/fix_false_positives_for_performance_string_identifier_argument.md
+++ b/changelog/fix_false_positives_for_performance_string_identifier_argument.md
@@ -1,0 +1,1 @@
+* [#492](https://github.com/rubocop/rubocop-performance/issues/492): Fix false positives for `Performance/StringIdentifierArgument` when using interpolated string argument. ([@koic][])

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -44,26 +44,19 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
         RUBY
       end
 
-      if described_class::INTERPOLATION_IGNORE_METHODS.include?(method)
-        it 'does not register an offense when using string interpolation for `#{method}` method' do
-          # NOTE: These methods don't support `::` when passing a symbol. const_get('A::B') is valid
-          # but const_get(:'A::B') isn't. Since interpolated arguments may contain any content these
-          # cases are not detected as an offense to prevent false positives.
-          expect_no_offenses(<<~RUBY)
-            #{method}("\#{module_name}class_name")
-          RUBY
-        end
-      else
-        it 'registers an offense when using interpolated string argument' do
-          expect_offense(<<~RUBY, method: method)
-            #{method}("do_something_\#{var}")
-            _{method} ^^^^^^^^^^^^^^^^^^^^^ Use `:"do_something_\#{var}"` instead of `"do_something_\#{var}"`.
-          RUBY
+      it 'does not register an offense when using string interpolation for `#{method}` method' do
+        # NOTE: These methods don't support `::` when passing a symbol. const_get('A::B') is valid
+        # but const_get(:'A::B') isn't. Since interpolated arguments may contain any content these
+        # cases are not detected as an offense to prevent false positives.
+        expect_no_offenses(<<~RUBY)
+          #{method}("\#{module_name}class_name")
+        RUBY
+      end
 
-          expect_correction(<<~RUBY)
-            #{method}(:"do_something_\#{var}")
-          RUBY
-        end
+      it 'does not register an offense when using interpolated string argument' do
+        expect_no_offenses(<<~RUBY)
+          #{method}("do_something_\#{var}")
+        RUBY
       end
     end
   end


### PR DESCRIPTION
This PR fixes false positives for `Performance/StringIdentifierArgument` when using interpolated string argument.
Converting a string with interpolation into a symbol degrades performance.

Fixes #492.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
