### PR TITLE
Fix `Performance/FixedSize` false positive when `count` is called with a `numblock`

### DIFF
--- a/changelog/fix_fix_performance_fixed_size_false.md
+++ b/changelog/fix_fix_performance_fixed_size_false.md
@@ -1,0 +1,1 @@
+* [#494](https://github.com/rubocop/rubocop-performance/pull/494): Fix `Performance/FixedSize` false positive when `count` is called with a `numblock`. ([@dvandersluis][])

--- a/lib/rubocop/cop/performance/fixed_size.rb
+++ b/lib/rubocop/cop/performance/fixed_size.rb
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def allowed_parent?(node)
-          node&.type?(:casgn, :block)
+          node&.type?(:casgn, :any_block)
         end
 
         def contains_splat?(node)

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe RuboCop::Cop::Performance::FixedSize, :config do
       expect_no_offenses("#{variable}.count { |v| v == 'a' }")
     end
 
+    it 'accepts calling count with a numblock', :ruby27 do
+      expect_no_offenses("#{variable}.count { _1 == 'a' }")
+    end
+
+    it 'accepts calling count with an itblock', :ruby34 do
+      expect_no_offenses("#{variable}.count { it == 'a' }")
+    end
+
     it 'accepts calling count with a symbol proc' do
       expect_no_offenses("#{variable}.count(&:any?) ")
     end


### PR DESCRIPTION
Fixes https://github.com/standardrb/standard/issues/702.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
