### PR TITLE
Support `it` block parameter in `Performance` cops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
           sed -e "/gem 'rubocop', github: 'rubocop\/rubocop'/d" \
               -e "/gem 'rubocop-rspec',/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rubocop', '1.72.1' # Specify the oldest supported RuboCop version
+            gem 'rubocop', '1.75.0' # Specify the oldest supported RuboCop version
           EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1

--- a/changelog/new_support_itblock_in_performance_cops.md
+++ b/changelog/new_support_itblock_in_performance_cops.md
@@ -1,0 +1,1 @@
+* [#496](https://github.com/rubocop/rubocop-performance/pull/496): Support `it` block parameter in `Performance` cops. ([@koic][])

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -52,6 +52,7 @@ module RuboCop
           check(node)
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/performance/zip_without_block.rb
+++ b/lib/rubocop/cop/performance/zip_without_block.rb
@@ -28,6 +28,7 @@ module RuboCop
           {
             (block (call !nil? RESTRICT_ON_SEND) (args (arg _)) (array (lvar _)))
             (numblock (call !nil? RESTRICT_ON_SEND) 1 (array (lvar _)))
+            (itblock (call !nil? RESTRICT_ON_SEND) :it (array (lvar _)))
           }
         PATTERN
 

--- a/rubocop-performance.gemspec
+++ b/rubocop-performance.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency('lint_roller', '~> 1.1')
-  s.add_dependency('rubocop', '>= 1.72.1', '< 2.0')
+  s.add_dependency('rubocop', '>= 1.75.0', '< 2.0')
   s.add_dependency('rubocop-ast', '>= 1.38.0', '< 2.0')
 end

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
     end
   end
 
+  describe 'when using `select` with block argument after `select` with `it` block', :ruby34, unsupported_on: :parser do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        model.select { it.foo }.select { |item| item.bar }
+                                ^^^^^^ Use unchained `select` and `select!` (followed by `return array` if required) instead of chaining `select...select`.
+      RUBY
+    end
+  end
+
   describe 'when using `select` with positional arguments after `select`' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall, :config do
     RUBY
   end
 
+  it 'accepts when using `block.call` with `it` block argument', :ruby34, unsupported_on: :parser do
+    expect_no_offenses(<<~RUBY)
+      def method(&block)
+        block.call { it.do_something }
+      end
+    RUBY
+  end
+
   it 'accepts another block being passed along with other args' do
     expect_no_offenses(<<~RUBY)
       def method(&block)

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -138,6 +138,19 @@ RSpec.describe RuboCop::Cop::Performance::TimesMap, :config do
           RUBY
         end
       end
+
+      context 'when using `it` parameter', :ruby34, unsupported_on: :parser do
+        it 'registers an offense and corrects' do
+          expect_offense(<<~RUBY, method: method)
+            4.times.#{method} { it.to_s }
+            ^^^^^^^^^{method}^^^^^^^^^^^^ Use `Array.new(4)` with a block instead of `.times.#{method}`.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            Array.new(4) { it.to_s }
+          RUBY
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/performance/zip_without_block_spec.rb
+++ b/spec/rubocop/cop/performance/zip_without_block_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe RuboCop::Cop::Performance::ZipWithoutBlock, :config do
           [1, 2, 3].zip
         RUBY
       end
+
+      it 'registers an offense for collect with a numblock', :ruby34, unsupported_on: :parser do
+        expect_offense(<<~RUBY)
+          [1, 2, 3].collect { [it] }
+                    ^^^^^^^^^^^^^^^^ Use `zip` without a block argument instead.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          [1, 2, 3].zip
+        RUBY
+      end
     end
 
     context 'when using select with an array literal' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ RSpec.configure do |config|
 
   # Prism supports Ruby 3.3+ parsing.
   config.filter_run_excluding unsupported_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+
+  # With whitequark/parser, RuboCop supports Ruby syntax compatible with 2.0 to 3.3.
+  config.filter_run_excluding unsupported_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
+
   config.example_status_persistence_file_path = 'spec/examples.txt'
   config.disable_monkey_patching!
   config.warnings = true


### PR DESCRIPTION
This PR supports `it` block parameter in `Performance` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
