### PR TITLE
Fix `Performance/Count` cop error on empty selector block

### DIFF
--- a/changelog/fix_performance_count_cop_error_on_empty_selector_block.md
+++ b/changelog/fix_performance_count_cop_error_on_empty_selector_block.md
@@ -1,0 +1,1 @@
+* [#498](https://github.com/rubocop/rubocop-performance/pull/498): Fix `Performance/Count` cop error on empty selector block. ([@viralpraxis][])

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -87,7 +87,9 @@ module RuboCop
         end
 
         def eligible_node?(node)
-          !(node.parent && node.parent.block_type?)
+          return false if node.parent&.block_type?
+
+          node.receiver.call_type? || node.receiver.body
         end
 
         def source_starting_at(node)

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -353,4 +353,12 @@ RSpec.describe RuboCop::Cop::Performance::Count, :config do
       RUBY
     end
   end
+
+  context 'with `reject` with empty block body' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        array.reject {}.size
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Something like

```ruby
collection.reject { }.size
```

would lead to an error

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
