### PR TITLE
[Fix #500] Mark `Performance/MapCompact` cop as unsafe

### DIFF
--- a/changelog/fix_mark_performance_map_compact_cop_as.md
+++ b/changelog/fix_mark_performance_map_compact_cop_as.md
@@ -1,0 +1,1 @@
+* [#500](https://github.com/rubocop/rubocop-performance/issues/500): Mark `Performance/MapCompact` cop as unsafe. ([@jbpextra][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -194,7 +194,7 @@ Performance/IoReadlines:
 Performance/MapCompact:
   Description: 'Use `filter_map` instead of `collection.map(&:do_something).compact`.'
   Enabled: pending
-  SafeAutoCorrect: false
+  Safe: false
   VersionAdded: '1.11'
 
 Performance/MapMethodChain:

--- a/lib/rubocop/cop/performance/map_compact.rb
+++ b/lib/rubocop/cop/performance/map_compact.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This cop identifies places where `map { ... }.compact` can be replaced by `filter_map`.
       #
       # @safety
-      #   This cop's autocorrection is unsafe because `map { ... }.compact` might yield
+      #   This cop is unsafe because `map { ... }.compact` might yield
       #   different results than `filter_map`. As illustrated in the example, `filter_map`
       #   also filters out falsy values, while `compact` only gets rid of `nil`.
       #


### PR DESCRIPTION
**Replace this text with a summary of the changes in your PR.
`Performance/MapCompact` is marked as safe but it should not be as the suggested refactoring is not equivalent
```ruby
[true, false, nil].compact              #=> [true, false]
[true, false, nil].filter_map(&:itself) #=> [true]
```
This is confusing for new Ruby developers.
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
