### PR TITLE
Actualize references

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -67,7 +67,6 @@ Performance/ChainArrayAllocation:
   Description: >-
                   Instead of chaining array methods that allocate new arrays, mutate an
                   existing array.
-  Reference: 'https://twitter.com/schneems/status/1034123879978029057'
   Enabled: false
   VersionAdded: '0.59'
 
@@ -187,7 +186,7 @@ Performance/InefficientHashSearch:
 
 Performance/IoReadlines:
   Description: 'Use `IO.each_line` (`IO#each_line`) instead of `IO.readlines` (`IO#readlines`).'
-  Reference: 'https://docs.gitlab.com/ee/development/performance.html#reading-from-files-and-other-data-sources'
+  Reference: 'https://docs.gitlab.com/development/performance/#reading-from-files-and-other-data-sources'
   Enabled: false
   VersionAdded: '1.7'
 


### PR DESCRIPTION
```
$ bundle exec rake references:verify
ERROR: https://twitter.com/schneems/status/1034123879978029057 (302)
ERROR: https://docs.gitlab.com/ee/development/performance.html#reading-from-files-and-other-data-sources (301)
```

Twitter 302 is due to domain change, but the tweat actually does not exist anymore (see https://x.com/schneems/status/1034123879978029057)

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.

[1]: https://chris.beams.io/posts/git-commit/
