### PR TITLE
Fix autocorrection syntax error for `Performance/Count` with multiline calls

### DIFF
--- a/changelog/fix_performance_count_multiline_error.md
+++ b/changelog/fix_performance_count_multiline_error.md
@@ -1,0 +1,1 @@
+* [#504](https://github.com/rubocop/rubocop-performance/pull/504): Fix autocorrection syntax error for `Performance/Count` with multiline calls. ([@lovro-bikic][])

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -81,7 +81,7 @@ module RuboCop
 
           range = source_starting_at(node) { |n| n.loc.dot.begin_pos }
 
-          corrector.remove(range)
+          corrector.remove(range_with_surrounding_space(range, side: :left))
           corrector.replace(selector_loc, 'count')
           negate_reject(corrector, node) if selector == :reject
         end


### PR DESCRIPTION
Currently, `Performance/Count` will autocorrect:
```ruby
foo
  .select(&:something)
  .count
  .positive?
```
to:
```ruby
foo
  .count(&:something)

  .positive?
```
which is not valid syntax. This PR fixes autocorrection to:
```ruby
foo
  .count(&:something)
  .positive?
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
