### PR TITLE
Detect negated conditions with `Performance/DoubleStartEndWith`

### DIFF
--- a/changelog/change_double_start_end_negation.md
+++ b/changelog/change_double_start_end_negation.md
@@ -1,0 +1,1 @@
+* [#512](https://github.com/rubocop/rubocop-performance/issues/512): Detect negated conditions like `!foo.start_with('bar') && !foo.start_with('baz')` with `Performance/DoubleStartEndWith`. ([@earlopain][])

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -6,114 +6,245 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
       RuboCop::Config.new('Performance/DoubleStartEndWith' => { 'IncludeActiveSupportAliases' => false })
     end
 
-    context 'two #start_with? calls' do
-      context 'with the same receiver' do
-        context 'all parameters of the second call are pure' do
-          it 'registers an offense and corrects' do
-            expect_offense(<<~RUBY)
-              x.start_with?(a, b) || x.start_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x.start_with?("c", D)`.
-            RUBY
+    context '||' do
+      context 'two #start_with? calls' do
+        context 'with the same receiver' do
+          context 'all parameters of the second call are pure' do
+            it 'registers an offense and corrects' do
+              expect_offense(<<~RUBY)
+                x.start_with?(a, b) || x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x.start_with?("c", D)`.
+              RUBY
 
-            expect_correction(<<~RUBY)
-              x.start_with?(a, b, "c", D)
-            RUBY
+              expect_correction(<<~RUBY)
+                x.start_with?(a, b, "c", D)
+              RUBY
+            end
+          end
+
+          context 'one of the parameters of the second call is not pure' do
+            it "doesn't register an offense" do
+              expect_no_offenses('x.start_with?(a, "b") || x.start_with?(C, d)')
+            end
+          end
+
+          context 'with safe navigation' do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY)
+                x&.start_with?(a, b) || x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x&.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                x&.start_with?(a, b, "c", D)
+              RUBY
+            end
+
+            it 'registers an offense when the first start_with uses no safe navigation' do
+              expect_offense(<<~RUBY)
+                x.start_with?(a, b) || x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x&.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                x.start_with?(a, b, "c", D)
+              RUBY
+            end
+
+            it 'registers an offense when the second start_with uses no safe navigation' do
+              expect_offense(<<~RUBY)
+                x&.start_with?(a, b) || x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                x&.start_with?(a, b, "c", D)
+              RUBY
+            end
           end
         end
 
-        context 'one of the parameters of the second call is not pure' do
+        context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('x.start_with?(a, "b") || x.start_with?(C, d)')
-          end
-        end
-
-        context 'with safe navigation' do
-          it 'registers an offense' do
-            expect_offense(<<~RUBY)
-              x&.start_with?(a, b) || x&.start_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x&.start_with?("c", D)`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              x&.start_with?(a, b, "c", D)
-            RUBY
-          end
-
-          it 'registers an offense when the first start_with uses no safe navigation' do
-            expect_offense(<<~RUBY)
-              x.start_with?(a, b) || x&.start_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x&.start_with?("c", D)`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              x.start_with?(a, b, "c", D)
-            RUBY
-          end
-
-          it 'registers an offense when the second start_with uses no safe navigation' do
-            expect_offense(<<~RUBY)
-              x&.start_with?(a, b) || x.start_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x.start_with?("c", D)`.
-            RUBY
-
-            expect_correction(<<~RUBY)
-              x&.start_with?(a, b, "c", D)
-            RUBY
+            expect_no_offenses('x.start_with?("a") || y.start_with?("b")')
           end
         end
       end
 
-      context 'with different receivers' do
-        it "doesn't register an offense" do
-          expect_no_offenses('x.start_with?("a") || y.start_with?("b")')
-        end
-      end
-    end
+      context 'two #end_with? calls' do
+        context 'with the same receiver' do
+          context 'all parameters of the second call are pure' do
+            it 'registers an offense and corrects' do
+              expect_offense(<<~RUBY)
+                x.end_with?(a, b) || x.end_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.end_with?(a, b, "c", D)` instead of `x.end_with?(a, b) || x.end_with?("c", D)`.
+              RUBY
 
-    context 'two #end_with? calls' do
-      context 'with the same receiver' do
-        context 'all parameters of the second call are pure' do
-          it 'registers an offense and corrects' do
-            expect_offense(<<~RUBY)
-              x.end_with?(a, b) || x.end_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.end_with?(a, b, "c", D)` instead of `x.end_with?(a, b) || x.end_with?("c", D)`.
-            RUBY
+              expect_correction(<<~RUBY)
+                x.end_with?(a, b, "c", D)
+              RUBY
+            end
 
-            expect_correction(<<~RUBY)
-              x.end_with?(a, b, "c", D)
-            RUBY
+            it 'registers no offense when only the first call is negated' do
+              expect_no_offenses('!x.end_with?(a, b) || x.end_with?("c", D)')
+            end
+
+            it 'registers no offense when only the second call is negated' do
+              expect_no_offenses('x.end_with?(a, b) || !x.end_with?("c", D)')
+            end
+          end
+
+          context 'one of the parameters of the second call is not pure' do
+            it "doesn't register an offense" do
+              expect_no_offenses('x.end_with?(a, "b") || x.end_with?(C, d)')
+            end
           end
         end
 
-        context 'one of the parameters of the second call is not pure' do
+        context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('x.end_with?(a, "b") || x.end_with?(C, d)')
+            expect_no_offenses('x.end_with?("a") || y.end_with?("b")')
           end
         end
       end
 
-      context 'with different receivers' do
+      context 'a .start_with? and .end_with? call with the same receiver' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.end_with?("a") || y.end_with?("b")')
+          expect_no_offenses('x.start_with?("a") || x.end_with?("b")')
+        end
+      end
+
+      context 'two #starts_with? calls' do
+        it "doesn't register an offense" do
+          expect_no_offenses('x.starts_with?(a, b) || x.starts_with?("c", D)')
+        end
+      end
+
+      context 'two #ends_with? calls' do
+        it "doesn't register an offense" do
+          expect_no_offenses('x.ends_with?(a, b) || x.ends_with?("c", D)')
         end
       end
     end
 
-    context 'a .start_with? and .end_with? call with the same receiver' do
-      it "doesn't register an offense" do
-        expect_no_offenses('x.start_with?("a") || x.end_with?("b")')
-      end
-    end
+    context '&&' do
+      context 'two #start_with? calls' do
+        context 'with the same receiver' do
+          context 'all parameters of the second call are pure' do
+            it 'registers an offense and corrects' do
+              expect_offense(<<~RUBY)
+                !x.start_with?(a, b) && !x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.start_with?(a, b, "c", D)` instead of `!x.start_with?(a, b) && !x.start_with?("c", D)`.
+              RUBY
 
-    context 'two #starts_with? calls' do
-      it "doesn't register an offense" do
-        expect_no_offenses('x.starts_with?(a, b) || x.starts_with?("c", D)')
-      end
-    end
+              expect_correction(<<~RUBY)
+                !x.start_with?(a, b, "c", D)
+              RUBY
+            end
 
-    context 'two #ends_with? calls' do
-      it "doesn't register an offense" do
-        expect_no_offenses('x.ends_with?(a, b) || x.ends_with?("c", D)')
+            it 'registers no offense when only the first call is negated' do
+              expect_no_offenses('!x.start_with?(a, b) && x.start_with?("c", D)')
+            end
+
+            it 'registers no offense when only the second call is negated' do
+              expect_no_offenses('x.start_with?(a, b) && !x.start_with?("c", D)')
+            end
+          end
+
+          context 'one of the parameters of the second call is not pure' do
+            it "doesn't register an offense" do
+              expect_no_offenses('!x.start_with?(a, "b") && !x.start_with?(C, d)')
+            end
+          end
+
+          context 'with safe navigation' do
+            it 'registers an offense' do
+              expect_offense(<<~RUBY)
+                !x&.start_with?(a, b) && !x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x&.start_with?(a, b, "c", D)` instead of `!x&.start_with?(a, b) && !x&.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                !x&.start_with?(a, b, "c", D)
+              RUBY
+            end
+
+            it 'registers an offense when the first start_with uses no safe navigation' do
+              expect_offense(<<~RUBY)
+                !x.start_with?(a, b) && !x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.start_with?(a, b, "c", D)` instead of `!x.start_with?(a, b) && !x&.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                !x.start_with?(a, b, "c", D)
+              RUBY
+            end
+
+            it 'registers an offense when the second start_with uses no safe navigation' do
+              expect_offense(<<~RUBY)
+                !x&.start_with?(a, b) && !x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x&.start_with?(a, b, "c", D)` instead of `!x&.start_with?(a, b) && !x.start_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                !x&.start_with?(a, b, "c", D)
+              RUBY
+            end
+          end
+        end
+
+        context 'with different receivers' do
+          it "doesn't register an offense" do
+            expect_no_offenses('!x.start_with?("a") && !y.start_with?("b")')
+          end
+        end
+      end
+
+      context 'two #end_with? calls' do
+        context 'with the same receiver' do
+          context 'all parameters of the second call are pure' do
+            it 'registers an offense and corrects' do
+              expect_offense(<<~RUBY)
+                !x.end_with?(a, b) && !x.end_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.end_with?(a, b, "c", D)` instead of `!x.end_with?(a, b) && !x.end_with?("c", D)`.
+              RUBY
+
+              expect_correction(<<~RUBY)
+                !x.end_with?(a, b, "c", D)
+              RUBY
+            end
+          end
+
+          context 'one of the parameters of the second call is not pure' do
+            it "doesn't register an offense" do
+              expect_no_offenses('!x.end_with?(a, "b") && !x.end_with?(C, d)')
+            end
+          end
+        end
+
+        context 'with different receivers' do
+          it "doesn't register an offense" do
+            expect_no_offenses('!x.end_with?("a") && !y.end_with?("b")')
+          end
+        end
+      end
+
+      context 'a .start_with? and .end_with? call with the same receiver' do
+        it "doesn't register an offense" do
+          expect_no_offenses('!x.start_with?("a") && !x.end_with?("b")')
+        end
+      end
+
+      context 'two #starts_with? calls' do
+        it "doesn't register an offense" do
+          expect_no_offenses('!x.starts_with?(a, b) && !x.starts_with?("c", D)')
+        end
+      end
+
+      context 'two #ends_with? calls' do
+        it "doesn't register an offense" do
+          expect_no_offenses('!x.ends_with?(a, b) && !x.ends_with?("c", D)')
+        end
       end
     end
   end


### PR DESCRIPTION
Also check for `!str.start_with?(foo) && !str.start_with?(bar)` and recommend to change it to `!str.start_with?(foo, bar)`.

Refactored the cop a bit to make it easier to extend for this.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
