### PR TITLE
[Fix #517] Fix false positives for `Performance/RedundantStringChars`

### DIFF
--- a/changelog/fix_false_positives_for_performance_redundant_string_chars.md
+++ b/changelog/fix_false_positives_for_performance_redundant_string_chars.md
@@ -1,0 +1,1 @@
+* [#517](https://github.com/rubocop/rubocop-performance/issues/517): Fix false positives for `Performance/RedundantStringChars` when using `str.chars[0, 2]`. ([@koic][])

--- a/lib/rubocop/cop/performance/redundant_string_chars.rb
+++ b/lib/rubocop/cop/performance/redundant_string_chars.rb
@@ -54,6 +54,7 @@ module RuboCop
         def on_send(node)
           return unless (receiver, method, args = redundant_chars_call?(node))
           return if method == :last && !args.empty?
+          return if args.count == 2
 
           range = offense_range(receiver, node)
           message = build_message(method, args)

--- a/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_string_chars_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe RuboCop::Cop::Performance::RedundantStringChars, :config do
     RUBY
   end
 
+  it 'does not register an offense and corrects when using `str.chars[0, 2]`' do
+    expect_no_offenses(<<~RUBY)
+      str.chars[0, 2]
+    RUBY
+  end
+
   it 'does not register an offense when using `str.chars.max`' do
     expect_no_offenses(<<~RUBY)
       str.chars.max


### PR DESCRIPTION
Fix false positives for `Performance/RedundantStringChars` when using `str.chars[0, 2]`.

Fixes #517.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
