### PR TITLE
[Fix rubocop#509] Fix a false positive for Performance/RedundantMatch

### DIFF
--- a/changelog/fix_false_positive_for_performance_redundant_match.md
+++ b/changelog/fix_false_positive_for_performance_redundant_match.md
@@ -1,0 +1,1 @@
+* [#509](https://github.com/rubocop/rubocop-performance/issues/509): Fix a false positive for `Performance/RedundantMatch` when numbered capture variable is used after match. ([@5hun-s][])

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -103,6 +103,38 @@ RSpec.describe RuboCop::Cop::Performance::RedundantMatch, :config do
     expect_no_offenses('match("bar")')
   end
 
+  it 'does not register an error when numbered capture variable is used after match with conditional' do
+    expect_no_offenses(<<~RUBY)
+      def method(str)
+        puts $1 if str.match(/regex/)
+      end
+    RUBY
+  end
+
+  it 'does not register an error when numbered capture variable is used after match without conditional' do
+    expect_no_offenses(<<~RUBY)
+      def method(str)
+        str.match(/regex/)
+        puts $1
+      end
+    RUBY
+  end
+
+  it 'does not register an error when numbered capture variable is used after a match in a conditional expression' do
+    expect_no_offenses(<<~RUBY)
+      def method(str)
+        puts str.match(/regex/) ? $1 : ''
+      end
+    RUBY
+  end
+
+  it 'does not register an error when numbered capture variable is used in a subsequent statement after match' do
+    expect_no_offenses(<<~RUBY)
+      exit unless str.match(/regex/)
+      puts $1
+    RUBY
+  end
+
   it 'formats error message correctly for something if str.match(/regex/)' do
     expect_offense(<<~RUBY)
       something if str.match(/regex/)


### PR DESCRIPTION
Fix https://github.com/rubocop/rubocop-performance/issues/509

This PR fixes a false positive for Performance/RedundantMatch when numbered capture variable is used after match.

Also, refactor `on_send` method to resolve Metrics/CyclomaticComplexity

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
