### PR TITLE
[Fix #510] Clarify `Performance/RegexpMatch` message for `!~`

### DIFF
--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -81,7 +81,7 @@ module RuboCop
         # Constants are included in this list because it is unlikely that
         # someone will store `nil` as a constant and then use it for comparison
         TYPES_IMPLEMENTING_MATCH = %i[const regexp str sym].freeze
-        MSG = 'Use `match?` instead of `%<current>s` when `MatchData` is not used.'
+        MSG = 'Use `%<negation>smatch?` instead of `%<current>s` when `MatchData` is not used.'
 
         def_node_matcher :match_method?, <<~PATTERN
           {
@@ -175,7 +175,9 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, current: node.loc.selector.source)
+          negation = ('!' if node.send_type? && node.method?(:!~))
+
+          format(MSG, negation: negation, current: node.loc.selector.source)
         end
 
         def last_match_used?(match_node)

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -370,6 +370,17 @@ RSpec.describe RuboCop::Cop::Performance::RegexpMatch, :config do
     RUBY
   end
 
+  it 'registers an offense with a negated message when using `!~`' do
+    expect_offense(<<~RUBY)
+      puts 1 if foo !~ /re/
+                ^^^^^^^^^^^ Use `!match?` instead of `!~` when `MatchData` is not used.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      puts 1 if !/re/.match?(foo)
+    RUBY
+  end
+
   it 'registers an offense when a regexp used independently with a regexp used in `if` are mixed' do
     expect_offense(<<~RUBY)
       def foo


### PR DESCRIPTION
The offense message said to use `match?` instead of `!~`, but following that wording literally when correcting by hand negates the logic of the expression. Prefix the suggested method with `!` for `!~`, in the same way as `Performance/StringInclude` does, so that the message guides manual corrections that preserve behavior. The autocorrection was already correct and is unchanged.

Fixes #510.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
