### PR TITLE
[Fix #438] Fix an incorrect autocorrect for Performance/ConstantRegex…

### DIFF
--- a/changelog/fix_an_incorrect_autocorrect_for_performance_constant_regexp.md
+++ b/changelog/fix_an_incorrect_autocorrect_for_performance_constant_regexp.md
@@ -1,0 +1,1 @@
+* [#438](https://github.com/rubocop/rubocop-performance/issues/438): Fix an incorrect autocorrect for `Performance/ConstantRegexp` when a regexp is used as a pattern in pattern matching. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/constant_regexp.rb
+++ b/lib/rubocop/cop/performance/constant_regexp.rb
@@ -43,7 +43,8 @@ module RuboCop
         end
 
         def on_regexp(node)
-          return if within_allowed_assignment?(node) || !include_interpolated_const?(node) || node.single_interpolation?
+          return if within_allowed_assignment?(node) || within_pattern_matching?(node) ||
+                    !include_interpolated_const?(node) || node.single_interpolation?
 
           add_offense(node) do |corrector|
             corrector.insert_after(node, 'o')
@@ -54,6 +55,20 @@ module RuboCop
 
         def within_allowed_assignment?(node)
           node.each_ancestor(:casgn, :or_asgn).any?
+        end
+
+        # `/o` is invalid when a regexp is used as a pattern in pattern matching,
+        # so an offense should not be registered in that case.
+        def within_pattern_matching?(node)
+          pattern_matching = node.each_ancestor(:in_pattern, :any_match_pattern).first
+          return false unless pattern_matching
+
+          pattern = if pattern_matching.in_pattern_type?
+                      pattern_matching.children.first
+                    else
+                      pattern_matching.children[1]
+                    end
+          node.equal?(pattern) || node.each_ancestor.any? { |ancestor| ancestor.equal?(pattern) }
         end
 
         def_node_matcher :regexp_escape?, <<~PATTERN

--- a/spec/rubocop/cop/performance/constant_regexp_spec.rb
+++ b/spec/rubocop/cop/performance/constant_regexp_spec.rb
@@ -63,4 +63,19 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp, :config do
       str.match?(/\#{CONST}\#{do_something(1)}/)
     RUBY
   end
+
+  it 'does not register an offense when regexp is used as a pattern in `case`/`in`' do
+    expect_no_offenses(<<~RUBY)
+      case string
+      in /\#{CONST}/
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when regexp is used as a one-line `in` pattern' do
+    expect_no_offenses(<<~RUBY)
+      string in /\#{CONST}/
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/performance/constant_regexp_spec.rb
+++ b/spec/rubocop/cop/performance/constant_regexp_spec.rb
@@ -63,4 +63,88 @@ RSpec.describe RuboCop::Cop::Performance::ConstantRegexp, :config do
       str.match?(/\#{CONST}\#{do_something(1)}/)
     RUBY
   end
+
+  it 'does not register an offense when regexp is used as a pattern in `case`/`in`' do
+    expect_no_offenses(<<~RUBY)
+      case string
+      in /\#{CONST}/
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when regexp is used as a one-line `in` pattern' do
+    expect_no_offenses(<<~RUBY)
+      string in /\#{CONST}/
+    RUBY
+  end
+
+  context 'when Ruby 3.0 or higher', :ruby30 do
+    it 'does not register an offense when regexp is used as a rightward assignment pattern' do
+      expect_no_offenses(<<~RUBY)
+        string => /\#{CONST}/
+      RUBY
+    end
+  end
+
+  it 'does not register an offense when regexp is nested in an array pattern' do
+    expect_no_offenses(<<~RUBY)
+      case string
+      in [/\#{CONST}/, *]
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when regexp is nested in a hash pattern' do
+    expect_no_offenses(<<~RUBY)
+      case string
+      in {key: /\#{CONST}/}
+        do_something
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when regexp is nested in an alternative pattern' do
+    expect_no_offenses(<<~RUBY)
+      case string
+      in /\#{CONST}/ | String
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when regexp is used in an `in` pattern guard' do
+    expect_offense(<<~RUBY)
+      case string
+      in String if str.match?(/\#{CONST}/)
+                              ^^^^^^^^^^ Extract this regexp into a constant, memoize it, or append an `/o` option to its options.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case string
+      in String if str.match?(/\#{CONST}/o)
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense and corrects when regexp is used in the body of an `in` branch' do
+    expect_offense(<<~RUBY)
+      case string
+      in String
+        str.match?(/\#{CONST}/)
+                   ^^^^^^^^^^ Extract this regexp into a constant, memoize it, or append an `/o` option to its options.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      case string
+      in String
+        str.match?(/\#{CONST}/o)
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
…p in pattern matching

Fixes #438.

`Performance/ConstantRegexp` autocorrects an interpolated-constant regexp by appending the `/o` option. When the regexp is used as a pattern in pattern matching (`case/in`, one-line `in`), `/o` is invalid Ruby and the autocorrection produces broken code (`NODE_ONCE: unknown node`).

This skips registering an offense when the regexp is in a pattern-matching pattern position, mirroring the existing `within_allowed_assignment?` guard. Added specs for the `case/in` and one-line `in` forms.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
