### PR TITLE
[Fix #532] Fix false negatives for `Performance/ChainArrayAllocation`

### DIFF
--- a/changelog/fix_false_negatives_for_performance_chain_array_allocation.md
+++ b/changelog/fix_false_negatives_for_performance_chain_array_allocation.md
@@ -1,0 +1,1 @@
+* [#532](https://github.com/rubocop/rubocop-performance/issues/532): Fix false negatives for `Performance/ChainArrayAllocation` when using `flat_map`, `filter_map`, and `collect_concat`. ([@koic][])

--- a/lib/rubocop/cop/performance/chain_array_allocation.rb
+++ b/lib/rubocop/cop/performance/chain_array_allocation.rb
@@ -32,9 +32,9 @@ module RuboCop
 
         # These methods ALWAYS return a new array
         # after they're called it's safe to mutate the resulting array
-        ALWAYS_RETURNS_NEW_ARRAY = %i[* + - collect compact drop
-                                      drop_while flatten map reject
-                                      reverse rotate select shuffle sort
+        ALWAYS_RETURNS_NEW_ARRAY = %i[* + - collect collect_concat compact drop
+                                      drop_while filter_map flat_map flatten map
+                                      reject reverse rotate select shuffle sort
                                       take take_while transpose uniq
                                       values_at |].to_set.freeze
 

--- a/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
+++ b/spec/rubocop/cop/performance/chain_array_allocation_spec.rb
@@ -46,6 +46,43 @@ RSpec.describe RuboCop::Cop::Performance::ChainArrayAllocation, :config do
     end
   end
 
+  describe 'methods that always return a new array' do
+    it 'registers an offense for each link when chaining `flat_map`, `compact`, and `uniq`' do
+      expect_offense(<<~RUBY)
+        nodes.flat_map(&:file_ids).compact.uniq
+                                   ^^^^^^^ Use unchained `flat_map` and `compact!` (followed by `return array` if required) instead of chaining `flat_map...compact`.
+                                           ^^^^ Use unchained `compact` and `uniq!` (followed by `return array` if required) instead of chaining `compact...uniq`.
+      RUBY
+    end
+
+    it 'registers an offense for `flat_map` with a block followed by `uniq`' do
+      expect_offense(<<~RUBY)
+        nodes.flat_map { |node| node.file_ids }.uniq
+                                                ^^^^ Use unchained `flat_map` and `uniq!` (followed by `return array` if required) instead of chaining `flat_map...uniq`.
+      RUBY
+    end
+
+    it 'registers an offense for `filter_map` followed by `uniq`' do
+      expect_offense(<<~RUBY)
+        nodes.filter_map(&:file_id).uniq
+                                    ^^^^ Use unchained `filter_map` and `uniq!` (followed by `return array` if required) instead of chaining `filter_map...uniq`.
+      RUBY
+    end
+
+    it 'registers an offense for `collect_concat` followed by `uniq`' do
+      expect_offense(<<~RUBY)
+        nodes.collect_concat(&:file_ids).uniq
+                                         ^^^^ Use unchained `collect_concat` and `uniq!` (followed by `return array` if required) instead of chaining `collect_concat...uniq`.
+      RUBY
+    end
+
+    it 'does not register an offense for `flat_map` without chaining' do
+      expect_no_offenses(<<~RUBY)
+        nodes.flat_map(&:file_ids)
+      RUBY
+    end
+  end
+
   describe 'when using `Enumerable#lazy`' do
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
`flat_map`, `filter_map`, and `collect_concat` always return a new array, but they were missing from `ALWAYS_RETURNS_NEW_ARRAY`, so a chain built on them was only partially matched or not matched at all. `nodes.flat_map(&:file_ids).compact.uniq` reported one offense while the same-shaped `map` version reported two, and rewriting a flagged chain around `flat_map` silenced the cop without fixing the allocation it complained about.

Recognize the three methods as chain receivers. They are not added to `HAS_MUTATION_ALTERNATIVE` because no bang variants exist, so they are never suggested for `!` conversion.

Fixes #532.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
