### PR TITLE
Fix an error for `Performance/DeletePrefix` and `Performance/DeleteSuffix` cops

### DIFF
--- a/changelog/fix_an_error_for_performance_delete_suffix_and_delete_prefix_20260902030850.md
+++ b/changelog/fix_an_error_for_performance_delete_suffix_and_delete_prefix_20260902030850.md
@@ -1,0 +1,1 @@
+* [#537](https://github.com/rubocop/rubocop-performance/pull/537): Fix an error for `Performance/DeleteSuffix` and `Performance/DeletePrefix` when the receiver is itself a chained `sub` call. ([@viralpraxis][])

--- a/lib/rubocop/cop/performance/delete_prefix.rb
+++ b/lib/rubocop/cop/performance/delete_prefix.rb
@@ -64,12 +64,12 @@ module RuboCop
         }.freeze
 
         def_node_matcher :delete_prefix_candidate?, <<~PATTERN
-          (call $!nil? ${:gsub :gsub! :sub :sub!} (regexp (str $#literal_at_start?) (regopt)) (str $_))
+          (call !nil? ${:gsub :gsub! :sub :sub!} (regexp (str $#literal_at_start?) (regopt)) (str $_))
         PATTERN
 
         # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
-          return unless (receiver, bad_method, regexp_str, replace_string = delete_prefix_candidate?(node))
+          return unless (bad_method, regexp_str, replace_string = delete_prefix_candidate?(node))
           return unless replace_string.empty?
 
           good_method = PREFERRED_METHODS[bad_method]
@@ -81,9 +81,7 @@ module RuboCop
             regexp_str = interpret_string_escapes(regexp_str)
             string_literal = to_string_literal(regexp_str)
 
-            new_code = "#{receiver.source}#{node.loc.dot.source}#{good_method}(#{string_literal})"
-
-            corrector.replace(node, new_code)
+            corrector.replace(node.loc.selector.join(node.source_range.end), "#{good_method}(#{string_literal})")
           end
         end
         alias on_csend on_send

--- a/lib/rubocop/cop/performance/delete_suffix.rb
+++ b/lib/rubocop/cop/performance/delete_suffix.rb
@@ -64,12 +64,12 @@ module RuboCop
         }.freeze
 
         def_node_matcher :delete_suffix_candidate?, <<~PATTERN
-          (call $!nil? ${:gsub :gsub! :sub :sub!} (regexp (str $#literal_at_end?) (regopt)) (str $_))
+          (call !nil? ${:gsub :gsub! :sub :sub!} (regexp (str $#literal_at_end?) (regopt)) (str $_))
         PATTERN
 
         # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
-          return unless (receiver, bad_method, regexp_str, replace_string = delete_suffix_candidate?(node))
+          return unless (bad_method, regexp_str, replace_string = delete_suffix_candidate?(node))
           return unless replace_string.empty?
 
           good_method = PREFERRED_METHODS[bad_method]
@@ -81,9 +81,7 @@ module RuboCop
             regexp_str = interpret_string_escapes(regexp_str)
             string_literal = to_string_literal(regexp_str)
 
-            new_code = "#{receiver.source}#{node.loc.dot.source}#{good_method}(#{string_literal})"
-
-            corrector.replace(node, new_code)
+            corrector.replace(node.loc.selector.join(node.source_range.end), "#{good_method}(#{string_literal})")
           end
         end
         alias on_csend on_send

--- a/spec/rubocop/cop/performance/delete_prefix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_prefix_spec.rb
@@ -256,4 +256,18 @@ RSpec.describe RuboCop::Cop::Performance::DeletePrefix, :config do
       RUBY
     end
   end
+
+  context 'when the receiver is itself a chained call' do
+    it 'registers an offense for the outer call' do
+      expect_offense(<<~'RUBY')
+        s.sub(/\Aa/, '').sub(/\Ab/, '')
+          ^^^ Use `delete_prefix` instead of `sub`.
+                         ^^^ Use `delete_prefix` instead of `sub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        s.delete_prefix('a').delete_prefix('b')
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/performance/delete_suffix_spec.rb
+++ b/spec/rubocop/cop/performance/delete_suffix_spec.rb
@@ -256,4 +256,18 @@ RSpec.describe RuboCop::Cop::Performance::DeleteSuffix, :config do
       RUBY
     end
   end
+
+  context 'when the receiver is itself a chained call' do
+    it 'registers an offense for the outer call' do
+      expect_offense(<<~'RUBY')
+        s.sub(/a\z/, '').sub(/b\z/, '')
+          ^^^ Use `delete_suffix` instead of `sub`.
+                         ^^^ Use `delete_suffix` instead of `sub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        s.delete_suffix('a').delete_suffix('b')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```shell
$ bundle exec rubocop --debug --stdin /dev/stdin -A --config <(cat <<'YAML'
plugins:
  - rubocop-performance
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Performance/DeleteSuffix:
  Enabled: true
YAML
) <<'RUBY'
s.sub(/a\z/, '').sub(/b\z/, '')
RUBY

An error occurred while Performance/DeleteSuffix cop was inspecting /dev/stdin:1:0.
parser-3.3.12.0/lib/parser/source/tree_rewriter.rb:427:in 'Parser::Source::TreeRewriter#trigger_policy': Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
	from parser-3.3.12.0/lib/parser/source/tree_rewriter.rb:414:in 'Parser::Source::TreeRewriter#enforce_policy'
	from parser-3.3.12.0/lib/parser/source/tree_rewriter/action.rb:234:in 'Method#call'
	from parser-3.3.12.0/lib/parser/source/tree_rewriter/action.rb:234:in 'Parser::Source::TreeRewriter::Action#swallow'
	from parser-3.3.12.0/lib/parser/source/tree_rewriter/action.rb:98:in 'Parser::Source::TreeRewriter::Action#with'
	from parser-3.3.12.0/lib/parser/source/tree_rewriter/action.rb:125:in 'Parser::Source::TreeRewriter::Action#place_in_hierarchy'
	from parser-3.3.12.0/lib/parser/source/tree_rewriter/action.rb:107:in 'Parser::Source::TreeRewriter::Action#do_combine'
```

It seems like the correct way to fix it is to process each offense one-by-one.

Found by `rubocop-nightly`.


-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
