### PR TITLE
Fix an error for `Performance/StringIdentifierArgument` cop

### DIFF
--- a/changelog/fix_an_error_for_performance_string_identifier_argument_20260903023138.md
+++ b/changelog/fix_an_error_for_performance_string_identifier_argument_20260903023138.md
@@ -1,0 +1,1 @@
+* [#538](https://github.com/rubocop/rubocop-performance/pull/538): Fix an error for `Performance/StringIdentifierArgument` when the string argument is not valid in its encoding. ([@viralpraxis][])

--- a/lib/rubocop/cop/performance/string_identifier_argument.rb
+++ b/lib/rubocop/cop/performance/string_identifier_argument.rb
@@ -64,6 +64,7 @@ module RuboCop
 
           string_arguments(node).each do |string_argument|
             string_argument_value = string_argument.value
+            next unless string_argument_value.valid_encoding?
             next if string_argument_value.include?(' ') || string_argument_value.include?('::')
 
             register_offense(string_argument, string_argument_value)

--- a/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
+++ b/spec/rubocop/cop/performance/string_identifier_argument_spec.rb
@@ -135,4 +135,21 @@ RSpec.describe RuboCop::Cop::Performance::StringIdentifierArgument, :config do
       attr('foo')
     RUBY
   end
+
+  it 'does not register an offense when the string is not valid in its encoding' do
+    expect_no_offenses(<<~'RUBY')
+      a.send("\xF8")
+    RUBY
+  end
+
+  it 'registers an offense when the string is valid but not ASCII' do
+    expect_offense(<<~RUBY)
+      a.send("é")
+             ^^^ Use `:é` instead of `"é"`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a.send(:é)
+    RUBY
+  end
 end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin /dev/stdin -a --config <(cat <<'YAML'
plugins:
  - rubocop-performance
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Performance/StringIdentifierArgument:
  Enabled: true
YAML
) <<'RUBY'
a.send("\xF8")
RUBY
configuration from /proc/self/fd/11
Default configuration from config/default.yml
Inspecting 1 file
Scanning /dev/stdin
An error occurred while Performance/StringIdentifierArgument cop was inspecting /dev/stdin:1:0.
lib/rubocop/cop/performance/string_identifier_argument.rb:99:in 'String#to_sym': invalid symbol in encoding UTF-8 :"\xF8" (EncodingError)
	from lib/rubocop/cop/performance/string_identifier_argument.rb:99:in 'RuboCop::Cop::Performance::StringIdentifierArgument#argument_replacement'
	from lib/rubocop/cop/performance/string_identifier_argument.rb:88:in 'RuboCop::Cop::Performance::StringIdentifierArgument#register_offense'
	from lib/rubocop/cop/performance/string_identifier_argument.rb:69:in 'block in RuboCop::Cop::Performance::StringIdentifierArgument#on_send'
	from lib/rubocop/cop/commissioner.rb:145:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_restricted_cops'
```

Found by `rubocop-nightly`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [X] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
