### PR TITLE
Fix an error for `Performance/Squeeze`

### DIFF
--- a/changelog/fix_an_error_for_performance_squeeze.md
+++ b/changelog/fix_an_error_for_performance_squeeze.md
@@ -1,0 +1,1 @@
+* [#539](https://github.com/rubocop/rubocop-performance/pull/539): Fix an error for `Performance/Squeeze` when the receiver is itself a chained `gsub` call. ([@koic][])

--- a/lib/rubocop/cop/performance/squeeze.rb
+++ b/lib/rubocop/cop/performance/squeeze.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def_node_matcher :squeeze_candidate?, <<~PATTERN
           (call
-            $!nil? ${:gsub :gsub!}
+            !nil? ${:gsub :gsub!}
             (regexp
               (str $#repeating_literal?)
               (regopt))
@@ -37,7 +37,7 @@ module RuboCop
 
         # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
-          squeeze_candidate?(node) do |receiver, bad_method, regexp_str, replace_str|
+          squeeze_candidate?(node) do |bad_method, regexp_str, replace_str|
             regexp_str = regexp_str[0..-2] # delete '+' from the end
             regexp_str = interpret_string_escapes(regexp_str)
             return unless replace_str == regexp_str
@@ -51,9 +51,8 @@ module RuboCop
               # frozen strings are handled in the `to_string_literal`
               # implementation. Please remove it.
               string_literal = to_string_literal(replace_str.dup)
-              new_code = "#{receiver.source}#{node.loc.dot.source}#{good_method}(#{string_literal})"
 
-              corrector.replace(node, new_code)
+              corrector.replace(node.loc.selector.join(node.source_range.end), "#{good_method}(#{string_literal})")
             end
           end
         end

--- a/spec/rubocop/cop/performance/squeeze_spec.rb
+++ b/spec/rubocop/cop/performance/squeeze_spec.rb
@@ -62,4 +62,18 @@ RSpec.describe RuboCop::Cop::Performance::Squeeze, :config do
       str.squeeze("\n")
     RUBY
   end
+
+  context 'when the receiver is itself a chained call' do
+    it 'registers an offense for each call' do
+      expect_offense(<<~RUBY)
+        s.gsub(/a+/, 'a').gsub(/b+/, 'b')
+          ^^^^ Use `squeeze` instead of `gsub`.
+                          ^^^^ Use `squeeze` instead of `gsub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        s.squeeze('a').squeeze('b')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes an error for `Performance/Squeeze` when the receiver is itself a chained `gsub` call.

The corrector replaced the whole node including the receiver source, so the outer replacement swallowed the inner one. Limiting the replacement range to the selector and after makes the two ranges disjoint, and both offenses are detected and corrected in a single pass.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-performance/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
