### PR TITLE
[Fix] Fix an error for `Performance/Squeeze` on a chained `gsub` receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,4 @@
 [@a-lavis]: https://github.com/a-lavis
 [@jbpextra]: https://github.com/jbpextra
 [@lovro-bikic]: https://github.com/lovro-bikic
+[@pcbeingused333]: https://github.com/pcbeingused333

--- a/changelog/fix_an_error_for_performance_squeeze_20260908035244.md
+++ b/changelog/fix_an_error_for_performance_squeeze_20260908035244.md
@@ -1,0 +1,1 @@
+* [#XXXX](https://github.com/rubocop/rubocop-performance/pull/XXXX): Fix an error for `Performance/Squeeze` when the receiver is itself a chained `gsub` call. ([@pcbeingused333][])

--- a/changelog/fix_an_error_for_performance_squeeze_20260908035244.md
+++ b/changelog/fix_an_error_for_performance_squeeze_20260908035244.md
@@ -1,1 +1,1 @@
-* [#XXXX](https://github.com/rubocop/rubocop-performance/pull/XXXX): Fix an error for `Performance/Squeeze` when the receiver is itself a chained `gsub` call. ([@pcbeingused333][])
+* [#540](https://github.com/rubocop/rubocop-performance/pull/540): Fix an error for `Performance/Squeeze` when the receiver is itself a chained `gsub` call. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/squeeze.rb
+++ b/lib/rubocop/cop/performance/squeeze.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def_node_matcher :squeeze_candidate?, <<~PATTERN
           (call
-            $!nil? ${:gsub :gsub!}
+            !nil? ${:gsub :gsub!}
             (regexp
               (str $#repeating_literal?)
               (regopt))
@@ -37,7 +37,7 @@ module RuboCop
 
         # rubocop:disable-next Metrics/AbcSize
         def on_send(node)
-          squeeze_candidate?(node) do |receiver, bad_method, regexp_str, replace_str|
+          squeeze_candidate?(node) do |bad_method, regexp_str, replace_str|
             regexp_str = regexp_str[0..-2] # delete '+' from the end
             regexp_str = interpret_string_escapes(regexp_str)
             return unless replace_str == regexp_str
@@ -51,9 +51,8 @@ module RuboCop
               # frozen strings are handled in the `to_string_literal`
               # implementation. Please remove it.
               string_literal = to_string_literal(replace_str.dup)
-              new_code = "#{receiver.source}#{node.loc.dot.source}#{good_method}(#{string_literal})"
 
-              corrector.replace(node, new_code)
+              corrector.replace(node.loc.selector.join(node.source_range.end), "#{good_method}(#{string_literal})")
             end
           end
         end

--- a/spec/rubocop/cop/performance/squeeze_spec.rb
+++ b/spec/rubocop/cop/performance/squeeze_spec.rb
@@ -62,4 +62,18 @@ RSpec.describe RuboCop::Cop::Performance::Squeeze, :config do
       str.squeeze("\n")
     RUBY
   end
+
+  context 'when the receiver is itself a chained `gsub` call' do
+    it 'registers an offense for each call and corrects without clobbering' do
+      expect_offense(<<~RUBY)
+        str.gsub(/a+/, 'a').gsub(/b+/, 'b')
+            ^^^^ Use `squeeze` instead of `gsub`.
+                            ^^^^ Use `squeeze` instead of `gsub`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        str.squeeze('a').squeeze('b')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
`Performance/Squeeze` raises `Parser::ClobberingError` while autocorrecting when the receiver of a
`gsub` call is itself a `gsub` call the cop also flags.

MRE (same shape as #537):

```console
$ bundle exec rubocop --debug --stdin a.rb -A --config <(cat <<'YAML'
plugins:
  - rubocop-performance
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Performance/Squeeze:
  Enabled: true
YAML
) <<'RUBY'
s.gsub(/a+/, 'a').gsub(/b+/, 'b')
RUBY

An error occurred while Performance/Squeeze cop was inspecting a.rb:1:0.
Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
```

`on_send` built the replacement as `"#{receiver.source}#{dot}#{good_method}(...)"` and did
`corrector.replace(node, new_code)`, i.e. it rewrote the whole node including the receiver. When both
the inner and the outer `gsub` are offenses their replacement ranges overlap.

This applies the same fix as #537 (`Performance/DeletePrefix`/`DeleteSuffix`): drop the receiver
capture from the node pattern and replace only `node.loc.selector.join(node.source_range.end)` —
`gsub(/a+/, 'a')` -> `squeeze('a')` — leaving the receiver untouched, so chained corrections no longer
overlap.

```ruby
# before
s.gsub(/a+/, 'a').gsub(/b+/, 'b')
# after
s.squeeze('a').squeeze('b')
```

`Performance/StringInclude`, `Performance/StartWith` and `Performance/EndWith` clobber the same way on
`str.match?(/re/)` chained on another such call, but their fix is less mechanical — those cops also
match the `/re/.match?(str)` form where the receiver must be rewritten — so I've left them out of this
PR.

`bundle exec rake internal_investigation` and the `Performance/Squeeze`, `DeletePrefix`, `DeleteSuffix`
specs pass. New spec `when the receiver is itself a chained gsub call` fails on `master` and passes here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (no related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [x] Added an entry (file) to the changelog folder.

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.
