### PR TITLE
[Fix] Fix an error for `Performance/ArraySemiInfiniteRangeSlice` on a chained slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,4 @@
 [@a-lavis]: https://github.com/a-lavis
 [@jbpextra]: https://github.com/jbpextra
 [@lovro-bikic]: https://github.com/lovro-bikic
+[@pcbeingused333]: https://github.com/pcbeingused333

--- a/changelog/fix_an_error_for_performance_array_semi_infinite_range_slice_20260908040258.md
+++ b/changelog/fix_an_error_for_performance_array_semi_infinite_range_slice_20260908040258.md
@@ -1,0 +1,1 @@
+* [#541](https://github.com/rubocop/rubocop-performance/pull/541): Fix an error for `Performance/ArraySemiInfiniteRangeSlice` when the receiver is itself a chained slice. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
+++ b/lib/rubocop/cop/performance/array_semi_infinite_range_slice.rb
@@ -39,7 +39,7 @@ module RuboCop
         RESTRICT_ON_SEND = SLICE_METHODS
 
         def_node_matcher :endless_range_slice?, <<~PATTERN
-          (call $!any_str $%SLICE_METHODS $#endless_range?)
+          (call !any_str $%SLICE_METHODS $#endless_range?)
         PATTERN
 
         def_node_matcher :endless_range?, <<~PATTERN
@@ -50,12 +50,15 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          endless_range_slice?(node) do |receiver, method_name, range_node|
+          endless_range_slice?(node) do |method_name, range_node|
             prefer = range_node.begin ? :drop : :take
             message = format(MSG, prefer: prefer, current: method_name)
 
             add_offense(node, message: message) do |corrector|
-              corrector.replace(node, correction(receiver, range_node))
+              # Replace only the slice call (everything after the receiver), so chained slices such as
+              # `array.slice(1..).slice(2..)` do not produce overlapping corrections (Parser::ClobberingError).
+              range = node.receiver.source_range.end.join(node.source_range.end)
+              corrector.replace(range, ".#{correction(range_node)}")
             end
           end
         end
@@ -63,16 +66,14 @@ module RuboCop
 
         private
 
-        def correction(receiver, range_node)
-          method_call = if range_node.begin
-                          "drop(#{range_node.begin.value})"
-                        elsif range_node.irange_type?
-                          "take(#{range_node.end.value + 1})"
-                        else
-                          "take(#{range_node.end.value})"
-                        end
-
-          "#{receiver.source}.#{method_call}"
+        def correction(range_node)
+          if range_node.begin
+            "drop(#{range_node.begin.value})"
+          elsif range_node.irange_type?
+            "take(#{range_node.end.value + 1})"
+          else
+            "take(#{range_node.end.value})"
+          end
         end
       end
     end

--- a/spec/rubocop/cop/performance/array_semi_infinite_range_slice_spec.rb
+++ b/spec/rubocop/cop/performance/array_semi_infinite_range_slice_spec.rb
@@ -95,5 +95,17 @@ RSpec.describe RuboCop::Cop::Performance::ArraySemiInfiniteRangeSlice, :config d
         `str`[3..]
       RUBY
     end
+
+    it 'corrects chained slices without clobbering' do
+      expect_offense(<<~RUBY)
+        array.slice(1..).slice(2..)
+        ^^^^^^^^^^^^^^^^ Use `drop` instead of `slice` with semi-infinite range.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `drop` instead of `slice` with semi-infinite range.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        array.drop(1).drop(2)
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
`Performance/ArraySemiInfiniteRangeSlice` raises `Parser::ClobberingError` while autocorrecting when
the receiver of a slice call is itself a slice call the cop flags.

MRE (same shape as #537 / #540):

```console
$ bundle exec rubocop --debug --stdin a.rb -A --config <(cat <<'YAML'
plugins:
  - rubocop-performance
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
Performance/ArraySemiInfiniteRangeSlice:
  Enabled: true
YAML
) <<'RUBY'
array.slice(1..).slice(2..)
RUBY

An error occurred while Performance/ArraySemiInfiniteRangeSlice cop was inspecting a.rb:1:0.
Parser::Source::TreeRewriter detected clobbering (Parser::ClobberingError)
```

`on_send` built the correction as `"#{receiver.source}.#{method_call}"` and did
`corrector.replace(node, ...)`, i.e. it rewrote the whole node including the receiver. When both the
inner and the outer slice are offenses their replacement ranges overlap.

The fix replaces only the part after the receiver
(`node.receiver.source_range.end.join(node.source_range.end)`), so the two corrections no longer
overlap:

```ruby
# before
array.slice(1..).slice(2..)
# after
array.drop(1).drop(2)
```

The offense location (the whole node) and every existing correction are unchanged. Verified against
the `slice`, `[]`, beginless/endless-range, safe-navigation and string-literal cases in the spec.

`bundle exec rake internal_investigation` and the full `array_semi_infinite_range_slice_spec.rb` pass.
New spec `corrects chained slices without clobbering` fails on `master` (`Parser::ClobberingError`).

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote good commit messages.
* [ ] Commit message starts with `[Fix #issue-number]` (no related issue exists).
* [x] Feature branch is up-to-date with `master`.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`.
* [x] Added an entry (file) to the changelog folder.

This PR was generated with an AI assistant. I have reviewed the changes and run the tests locally.
