### PR TITLE
[Fix #536] Fix a false positive for `Performance/ReverseEach` when the value is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,4 @@
 [@a-lavis]: https://github.com/a-lavis
 [@jbpextra]: https://github.com/jbpextra
 [@lovro-bikic]: https://github.com/lovro-bikic
+[@pcbeingused333]: https://github.com/pcbeingused333

--- a/changelog/fix_a_false_positive_for_performance_reverse_each.md
+++ b/changelog/fix_a_false_positive_for_performance_reverse_each.md
@@ -1,0 +1,1 @@
+* [#536](https://github.com/rubocop/rubocop-performance/issues/536): Fix a false positive for `Performance/ReverseEach` when the value of `reverse.each` is used, such as an implicit method return. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -46,9 +46,11 @@ module RuboCop
         private
 
         def use_return_value?(node)
-          !!node.ancestors.detect do |ancestor|
-            ancestor.assignment? || ancestor.send_type? || ancestor.return_type?
-          end
+          # `reverse.each` returns the reversed receiver while `reverse_each` returns the
+          # original one, so the rewrite is only safe when the value is thrown away. This
+          # covers assignments, method chains and explicit `return`, but also implicit
+          # method returns and any other value context the ancestor walk used to miss.
+          (node.block_node || node).value_used?
         end
 
         def offense_range(node)

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -185,4 +185,41 @@ RSpec.describe RuboCop::Cop::Performance::ReverseEach, :config do
       return [1, 2, 3].reverse.each { |e| puts e }
     RUBY
   end
+
+  it 'does not register an offense when `reverse.each` is the implicit return value of a method' do
+    expect_no_offenses(<<~RUBY)
+      def process
+        [1, 2, 3].reverse.each { |e| puts e }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when `reverse.each` is the implicit return value after another statement' do
+    expect_no_offenses(<<~RUBY)
+      def process
+        log_start
+        [1, 2, 3].reverse.each { |e| puts e }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when `reverse.each` is followed by another statement in a method' do
+    expect_offense(<<~RUBY)
+      def process
+        [1, 2, 3].reverse.each { |e| puts e }
+                  ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+        log_done
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when `reverse.each` is the used value of an `if` branch' do
+    expect_no_offenses(<<~RUBY)
+      def process(flag)
+        if flag
+          [1, 2, 3].reverse.each { |e| puts e }
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #536.

### Problem

`reverse.each` returns the reversed receiver; `reverse_each` returns the original one. So the rewrite is only safe when the value is thrown away, and the cop already tries to protect that with `use_return_value?`:

```ruby
def use_return_value?(node)
  !!node.ancestors.detect do |ancestor|
    ancestor.assignment? || ancestor.send_type? || ancestor.return_type?
  end
end
```

That covers an assignment, a method chain and an explicit `return`, but not an **implicit method return**:

```ruby
def process
  [1, 2, 3].reverse.each { |e| puts e }   # flagged and safe-autocorrected
end

process # => [3, 2, 1] before, [1, 2, 3] after
```

### Fix

`use_return_value?` now asks `value_used?` on the `reverse.each` node (or its block). `value_used?` already knows about `begin`/`if`/`while`/array/interpolation/... contexts, so this also fixes the same class of miss for a used `if` branch etc., and a `reverse.each` that is genuinely a discarded statement is still flagged.

### Tests

Added specs for the implicit return (with and without a preceding statement), a used `if` branch, and a `reverse.each` followed by another statement (still an offense). The three new "does not register" specs fail on `master`.

`bundle exec rake spec`, `rake internal_investigation`, `rake documentation_syntax_check` and a `PARSER_ENGINE=parser_prism` run of the cop's spec are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)