### PR TITLE
[Fix #534] Fix a false positive for `Performance/RedundantBlockCall` on a shadowed block argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,4 @@
 [@a-lavis]: https://github.com/a-lavis
 [@jbpextra]: https://github.com/jbpextra
 [@lovro-bikic]: https://github.com/lovro-bikic
+[@pcbeingused333]: https://github.com/pcbeingused333

--- a/changelog/fix_a_false_positive_for_performance_redundant_block_call.md
+++ b/changelog/fix_a_false_positive_for_performance_redundant_block_call.md
@@ -1,0 +1,1 @@
+* [#534](https://github.com/rubocop/rubocop-performance/issues/534): Fix a false positive for `Performance/RedundantBlockCall` when a block argument is shadowed by a nested block and the method body is not itself a block. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -91,9 +91,13 @@ module RuboCop
         end
 
         def shadowed_block_argument?(body, block_argument_of_method_signature)
-          return false unless body.block_type?
+          return false unless body
 
-          body.arguments.map(&:source).include?(block_argument_of_method_signature.to_s)
+          name = block_argument_of_method_signature.to_s
+
+          body.each_node(:block).any? do |block_node|
+            block_node.arguments.map(&:source).include?(name)
+          end
         end
 
         def args_include_block_pass?(blockcall)

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -186,6 +186,29 @@ RSpec.describe RuboCop::Cop::Performance::RedundantBlockCall, :config do
     RUBY
   end
 
+  it 'accepts a block that is overridden by a block variable when a statement precedes the block' do
+    expect_no_offenses(<<~RUBY)
+      def method(&block)
+        do_setup
+        ->(i) { puts i }.then do |block|
+          block.call(1)
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a block that is overridden by a nested block variable' do
+    expect_no_offenses(<<~RUBY)
+      def method(&block)
+        [1, 2].each do |i|
+          [3, 4].each do |block|
+            block.call(i)
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'registers and corrects an offense when an optional block that is not overridden by block variable' do
     expect_offense(<<~RUBY)
       def method(&block)


### PR DESCRIPTION
Fixes #534.

### Problem

`RedundantBlockCall` skips a method when its block parameter is shadowed by an inner block, but the guard only fires when the method body *is* a block node:

```ruby
def shadowed_block_argument?(body, block_argument_of_method_signature)
  return false unless body.block_type?
  ...
end
```

A single statement before the block wraps the body in `begin`, so `body.block_type?` is `false` and the shadow is missed:

```ruby
def original(&outer)
  marker = :begin
  [-> { :inner }].each do |outer|
    return [marker, outer.call]   # rewritten to `yield`
  end
end

# before: [:begin, :inner]   after autocorrect: [:begin, :outer]
```

### Fix

`shadowed_block_argument?` now scans every `block` node in the body for an argument that shadows the method's block parameter, instead of only checking the body node itself. This matches what #220 was meant to do. As before, the cop bails on the whole method when a shadow is found (conservative, no scope analysis).

### Tests

Added specs for a shadowing block preceded by a statement, and a nested shadowing block. Both fail on `master`. The existing counterpart specs — a non-shadowing `do |_block|`, and the direct `do |block|` with no preceding statement — still pass.

`bundle exec rake spec`, `rake internal_investigation`, and a `PARSER_ENGINE=parser_prism` run of the cop's spec are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)