### PR TITLE
[Fix #535] Require a pure receiver in `Performance/DoubleStartEndWith`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -632,3 +632,4 @@
 [@a-lavis]: https://github.com/a-lavis
 [@jbpextra]: https://github.com/jbpextra
 [@lovro-bikic]: https://github.com/lovro-bikic
+[@pcbeingused333]: https://github.com/pcbeingused333

--- a/changelog/fix_double_start_end_with_impure_receiver.md
+++ b/changelog/fix_double_start_end_with_impure_receiver.md
@@ -1,0 +1,1 @@
+* [#535](https://github.com/rubocop/rubocop-performance/issues/535): Fix `Performance/DoubleStartEndWith` to not combine `start_with?`/`end_with?` calls when the shared receiver is not pure, since that changes how often the receiver is evaluated. ([@pcbeingused333][])

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -10,6 +10,10 @@ module RuboCop
       # `IncludeActiveSupportAliases` configuration option is used to check for
       # `starts_with?` and `ends_with?`. These methods are defined by Active Support.
       #
+      # The receiver is only combined when it is pure (a local variable, an
+      # instance variable, a constant, ...), since the original code evaluates it
+      # twice and the replacement evaluates it once.
+      #
       # @example
       #   # bad
       #   str.start_with?("a") || str.start_with?(Some::CONST)
@@ -63,7 +67,9 @@ module RuboCop
         private
 
         def check(node, receiver, method, first_call_args, second_call_args)
-          return unless receiver && second_call_args.all?(&:pure?)
+          # The receiver is evaluated twice in the original code and once in the
+          # replacement, so combining the calls is only equivalent when it is pure.
+          return unless receiver&.pure? && second_call_args.all?(&:pure?)
 
           combined_args = combine_args(first_call_args, second_call_args)
 

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -12,53 +12,53 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
           context 'all parameters of the second call are pure' do
             it 'registers an offense and corrects' do
               expect_offense(<<~RUBY)
-                x.start_with?(a, b) || x.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x.start_with?("c", D)`.
+                @x.start_with?(a, b) || @x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.start_with?(a, b, "c", D)` instead of `@x.start_with?(a, b) || @x.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                x.start_with?(a, b, "c", D)
+                @x.start_with?(a, b, "c", D)
               RUBY
             end
           end
 
           context 'one of the parameters of the second call is not pure' do
             it "doesn't register an offense" do
-              expect_no_offenses('x.start_with?(a, "b") || x.start_with?(C, d)')
+              expect_no_offenses('@x.start_with?(a, "b") || @x.start_with?(C, d)')
             end
           end
 
           context 'with safe navigation' do
             it 'registers an offense' do
               expect_offense(<<~RUBY)
-                x&.start_with?(a, b) || x&.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x&.start_with?("c", D)`.
+                @x&.start_with?(a, b) || @x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x&.start_with?(a, b, "c", D)` instead of `@x&.start_with?(a, b) || @x&.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                x&.start_with?(a, b, "c", D)
+                @x&.start_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers an offense when the first start_with uses no safe navigation' do
               expect_offense(<<~RUBY)
-                x.start_with?(a, b) || x&.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x&.start_with?("c", D)`.
+                @x.start_with?(a, b) || @x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.start_with?(a, b, "c", D)` instead of `@x.start_with?(a, b) || @x&.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                x.start_with?(a, b, "c", D)
+                @x.start_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers an offense when the second start_with uses no safe navigation' do
               expect_offense(<<~RUBY)
-                x&.start_with?(a, b) || x.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x&.start_with?(a, b, "c", D)` instead of `x&.start_with?(a, b) || x.start_with?("c", D)`.
+                @x&.start_with?(a, b) || @x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x&.start_with?(a, b, "c", D)` instead of `@x&.start_with?(a, b) || @x.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                x&.start_with?(a, b, "c", D)
+                @x&.start_with?(a, b, "c", D)
               RUBY
             end
           end
@@ -66,7 +66,17 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
 
         context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('x.start_with?("a") || y.start_with?("b")')
+            expect_no_offenses('@x.start_with?("a") || @y.start_with?("b")')
+          end
+        end
+
+        context 'with an impure receiver' do
+          it "doesn't register an offense for a bare method call receiver" do
+            expect_no_offenses('next_string.start_with?("a") || next_string.start_with?("b")')
+          end
+
+          it "doesn't register an offense for a method call chain receiver" do
+            expect_no_offenses('foo.bar.start_with?("a") || foo.bar.start_with?("b")')
           end
         end
       end
@@ -76,53 +86,53 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
           context 'all parameters of the second call are pure' do
             it 'registers an offense and corrects' do
               expect_offense(<<~RUBY)
-                x.end_with?(a, b) || x.end_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.end_with?(a, b, "c", D)` instead of `x.end_with?(a, b) || x.end_with?("c", D)`.
+                @x.end_with?(a, b) || @x.end_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.end_with?(a, b, "c", D)` instead of `@x.end_with?(a, b) || @x.end_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                x.end_with?(a, b, "c", D)
+                @x.end_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers no offense when only the first call is negated' do
-              expect_no_offenses('!x.end_with?(a, b) || x.end_with?("c", D)')
+              expect_no_offenses('!@x.end_with?(a, b) || @x.end_with?("c", D)')
             end
 
             it 'registers no offense when only the second call is negated' do
-              expect_no_offenses('x.end_with?(a, b) || !x.end_with?("c", D)')
+              expect_no_offenses('@x.end_with?(a, b) || !@x.end_with?("c", D)')
             end
           end
 
           context 'one of the parameters of the second call is not pure' do
             it "doesn't register an offense" do
-              expect_no_offenses('x.end_with?(a, "b") || x.end_with?(C, d)')
+              expect_no_offenses('@x.end_with?(a, "b") || @x.end_with?(C, d)')
             end
           end
         end
 
         context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('x.end_with?("a") || y.end_with?("b")')
+            expect_no_offenses('@x.end_with?("a") || @y.end_with?("b")')
           end
         end
       end
 
       context 'a .start_with? and .end_with? call with the same receiver' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.start_with?("a") || x.end_with?("b")')
+          expect_no_offenses('@x.start_with?("a") || @x.end_with?("b")')
         end
       end
 
       context 'two #starts_with? calls' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.starts_with?(a, b) || x.starts_with?("c", D)')
+          expect_no_offenses('@x.starts_with?(a, b) || @x.starts_with?("c", D)')
         end
       end
 
       context 'two #ends_with? calls' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.ends_with?(a, b) || x.ends_with?("c", D)')
+          expect_no_offenses('@x.ends_with?(a, b) || @x.ends_with?("c", D)')
         end
       end
     end
@@ -133,61 +143,61 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
           context 'all parameters of the second call are pure' do
             it 'registers an offense and corrects' do
               expect_offense(<<~RUBY)
-                !x.start_with?(a, b) && !x.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.start_with?(a, b, "c", D)` instead of `!x.start_with?(a, b) && !x.start_with?("c", D)`.
+                !@x.start_with?(a, b) && !@x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!@x.start_with?(a, b, "c", D)` instead of `!@x.start_with?(a, b) && !@x.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                !x.start_with?(a, b, "c", D)
+                !@x.start_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers no offense when only the first call is negated' do
-              expect_no_offenses('!x.start_with?(a, b) && x.start_with?("c", D)')
+              expect_no_offenses('!@x.start_with?(a, b) && @x.start_with?("c", D)')
             end
 
             it 'registers no offense when only the second call is negated' do
-              expect_no_offenses('x.start_with?(a, b) && !x.start_with?("c", D)')
+              expect_no_offenses('@x.start_with?(a, b) && !@x.start_with?("c", D)')
             end
           end
 
           context 'one of the parameters of the second call is not pure' do
             it "doesn't register an offense" do
-              expect_no_offenses('!x.start_with?(a, "b") && !x.start_with?(C, d)')
+              expect_no_offenses('!@x.start_with?(a, "b") && !@x.start_with?(C, d)')
             end
           end
 
           context 'with safe navigation' do
             it 'registers an offense' do
               expect_offense(<<~RUBY)
-                !x&.start_with?(a, b) && !x&.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x&.start_with?(a, b, "c", D)` instead of `!x&.start_with?(a, b) && !x&.start_with?("c", D)`.
+                !@x&.start_with?(a, b) && !@x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!@x&.start_with?(a, b, "c", D)` instead of `!@x&.start_with?(a, b) && !@x&.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                !x&.start_with?(a, b, "c", D)
+                !@x&.start_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers an offense when the first start_with uses no safe navigation' do
               expect_offense(<<~RUBY)
-                !x.start_with?(a, b) && !x&.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.start_with?(a, b, "c", D)` instead of `!x.start_with?(a, b) && !x&.start_with?("c", D)`.
+                !@x.start_with?(a, b) && !@x&.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!@x.start_with?(a, b, "c", D)` instead of `!@x.start_with?(a, b) && !@x&.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                !x.start_with?(a, b, "c", D)
+                !@x.start_with?(a, b, "c", D)
               RUBY
             end
 
             it 'registers an offense when the second start_with uses no safe navigation' do
               expect_offense(<<~RUBY)
-                !x&.start_with?(a, b) && !x.start_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x&.start_with?(a, b, "c", D)` instead of `!x&.start_with?(a, b) && !x.start_with?("c", D)`.
+                !@x&.start_with?(a, b) && !@x.start_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!@x&.start_with?(a, b, "c", D)` instead of `!@x&.start_with?(a, b) && !@x.start_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                !x&.start_with?(a, b, "c", D)
+                !@x&.start_with?(a, b, "c", D)
               RUBY
             end
           end
@@ -195,7 +205,7 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
 
         context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('!x.start_with?("a") && !y.start_with?("b")')
+            expect_no_offenses('!@x.start_with?("a") && !@y.start_with?("b")')
           end
         end
       end
@@ -205,45 +215,45 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
           context 'all parameters of the second call are pure' do
             it 'registers an offense and corrects' do
               expect_offense(<<~RUBY)
-                !x.end_with?(a, b) && !x.end_with?("c", D)
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!x.end_with?(a, b, "c", D)` instead of `!x.end_with?(a, b) && !x.end_with?("c", D)`.
+                !@x.end_with?(a, b) && !@x.end_with?("c", D)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `!@x.end_with?(a, b, "c", D)` instead of `!@x.end_with?(a, b) && !@x.end_with?("c", D)`.
               RUBY
 
               expect_correction(<<~RUBY)
-                !x.end_with?(a, b, "c", D)
+                !@x.end_with?(a, b, "c", D)
               RUBY
             end
           end
 
           context 'one of the parameters of the second call is not pure' do
             it "doesn't register an offense" do
-              expect_no_offenses('!x.end_with?(a, "b") && !x.end_with?(C, d)')
+              expect_no_offenses('!@x.end_with?(a, "b") && !@x.end_with?(C, d)')
             end
           end
         end
 
         context 'with different receivers' do
           it "doesn't register an offense" do
-            expect_no_offenses('!x.end_with?("a") && !y.end_with?("b")')
+            expect_no_offenses('!@x.end_with?("a") && !@y.end_with?("b")')
           end
         end
       end
 
       context 'a .start_with? and .end_with? call with the same receiver' do
         it "doesn't register an offense" do
-          expect_no_offenses('!x.start_with?("a") && !x.end_with?("b")')
+          expect_no_offenses('!@x.start_with?("a") && !@x.end_with?("b")')
         end
       end
 
       context 'two #starts_with? calls' do
         it "doesn't register an offense" do
-          expect_no_offenses('!x.starts_with?(a, b) && !x.starts_with?("c", D)')
+          expect_no_offenses('!@x.starts_with?(a, b) && !@x.starts_with?("c", D)')
         end
       end
 
       context 'two #ends_with? calls' do
         it "doesn't register an offense" do
-          expect_no_offenses('!x.ends_with?(a, b) && !x.ends_with?("c", D)')
+          expect_no_offenses('!@x.ends_with?(a, b) && !@x.ends_with?("c", D)')
         end
       end
     end
@@ -259,12 +269,12 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
         context 'all parameters of the second call are pure' do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY)
-              x.start_with?(a, b) || x.start_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.start_with?(a, b, "c", D)` instead of `x.start_with?(a, b) || x.start_with?("c", D)`.
+              @x.start_with?(a, b) || @x.start_with?("c", D)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.start_with?(a, b, "c", D)` instead of `@x.start_with?(a, b) || @x.start_with?("c", D)`.
             RUBY
 
             expect_correction(<<~RUBY)
-              x.start_with?(a, b, "c", D)
+              @x.start_with?(a, b, "c", D)
             RUBY
           end
         end
@@ -276,12 +286,12 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
         context 'all parameters of the second call are pure' do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY)
-              x.end_with?(a, b) || x.end_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.end_with?(a, b, "c", D)` instead of `x.end_with?(a, b) || x.end_with?("c", D)`.
+              @x.end_with?(a, b) || @x.end_with?("c", D)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.end_with?(a, b, "c", D)` instead of `@x.end_with?(a, b) || @x.end_with?("c", D)`.
             RUBY
 
             expect_correction(<<~RUBY)
-              x.end_with?(a, b, "c", D)
+              @x.end_with?(a, b, "c", D)
             RUBY
           end
         end
@@ -293,12 +303,12 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
         context 'all parameters of the second call are pure' do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY)
-              x.starts_with?(a, b) || x.starts_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.starts_with?(a, b, "c", D)` instead of `x.starts_with?(a, b) || x.starts_with?("c", D)`.
+              @x.starts_with?(a, b) || @x.starts_with?("c", D)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.starts_with?(a, b, "c", D)` instead of `@x.starts_with?(a, b) || @x.starts_with?("c", D)`.
             RUBY
 
             expect_correction(<<~RUBY)
-              x.starts_with?(a, b, "c", D)
+              @x.starts_with?(a, b, "c", D)
             RUBY
           end
         end
@@ -306,7 +316,7 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
         context 'one of the parameters of the second call is not pure' do
           it "doesn't register an offense" do
             expect_no_offenses(<<~RUBY)
-              x.starts_with?(a, "b") || x.starts_with?(C, d)
+              @x.starts_with?(a, "b") || @x.starts_with?(C, d)
             RUBY
           end
         end
@@ -314,7 +324,7 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
 
       context 'with different receivers' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.starts_with?("a") || y.starts_with?("b")')
+          expect_no_offenses('@x.starts_with?("a") || @y.starts_with?("b")')
         end
       end
     end
@@ -324,26 +334,26 @@ RSpec.describe RuboCop::Cop::Performance::DoubleStartEndWith, :config do
         context 'all parameters of the second call are pure' do
           it 'registers an offense and corrects' do
             expect_offense(<<~RUBY)
-              x.ends_with?(a, b) || x.ends_with?("c", D)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `x.ends_with?(a, b, "c", D)` instead of `x.ends_with?(a, b) || x.ends_with?("c", D)`.
+              @x.ends_with?(a, b) || @x.ends_with?("c", D)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `@x.ends_with?(a, b, "c", D)` instead of `@x.ends_with?(a, b) || @x.ends_with?("c", D)`.
             RUBY
 
             expect_correction(<<~RUBY)
-              x.ends_with?(a, b, "c", D)
+              @x.ends_with?(a, b, "c", D)
             RUBY
           end
         end
 
         context 'one of the parameters of the second call is not pure' do
           it "doesn't register an offense" do
-            expect_no_offenses('x.ends_with?(a, "b") || x.ends_with?(C, d)')
+            expect_no_offenses('@x.ends_with?(a, "b") || @x.ends_with?(C, d)')
           end
         end
       end
 
       context 'with different receivers' do
         it "doesn't register an offense" do
-          expect_no_offenses('x.ends_with?("a") || y.ends_with?("b")')
+          expect_no_offenses('@x.ends_with?("a") || @y.ends_with?("b")')
         end
       end
     end


### PR DESCRIPTION
Fixes #535.

### Problem

`str.start_with?(a) || str.start_with?(b)` is only equivalent to `str.start_with?(a, b)` when `str` is evaluated the same number of times. The cop already required the **arguments** of the second call to be pure:

```ruby
return unless receiver && second_call_args.all?(&:pure?)
```

but not the **receiver**, so it combined and autocorrected code with a side-effecting receiver:

```ruby
class Sequence
  def next_string
    @calls += 1
    @calls == 1 ? "x" : "b"
  end
end

sequence.next_string.start_with?("a") || sequence.next_string.start_with?("b")
# => true  (receiver called twice)

# autocorrected to:
sequence.next_string.start_with?("a", "b")
# => false (receiver called once)
```

### Fix

`check` now also requires `receiver.pure?`. A pure receiver (local variable, instance variable, constant, literal) is safe to reference once instead of twice; a bare method call or a method-call chain is not.

The existing specs used a bare `x` receiver, which parses as `(send nil :x)` — an impure method call — so they now use `@x`. Two regression specs cover a bare method-call receiver and a chained one.

`bundle exec rake spec`, `rake internal_investigation`, and a `PARSER_ENGINE=parser_prism` run are green; `project_spec.rb` (no `@safety`/config drift) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)